### PR TITLE
Prevent Java from handling externally generated signals

### DIFF
--- a/lib/jdbc.js
+++ b/lib/jdbc.js
@@ -1,5 +1,6 @@
 var _ = require('underscore');
 var java = require('java');
+java.options.push('-Xrs');
 
 function trim1 (str) {
   return (str || '').replace(/^\s\s*/, '').replace(/\s\s*$/, '');
@@ -13,9 +14,9 @@ function JDBCConn() {
 JDBCConn.prototype.initialize = function(config, callback) {
   var self = this;
   self._config = config;
-  
+
   java.classpath.push(self._config.libpath);
-  
+
   java.newInstance(self._config.drivername, function(err, driver) {
     if (err) {
       return callback(err);
@@ -57,7 +58,7 @@ JDBCConn.prototype.open = function(callback) {
 
 JDBCConn.prototype.close = function(callback) {
   var self = this;
-  
+
   if (self._conn) {
     self._conn.close(function(err) {
       if (err) {
@@ -66,7 +67,7 @@ JDBCConn.prototype.close = function(callback) {
         self._conn = null;
         return callback(null);
       }
-    }); 
+    });
   }
 };
 


### PR DESCRIPTION
This prevents Java from handling external generated signals.  Such as SIGINIT.  Info on flags used [here](http://www-01.ibm.com/support/knowledgecenter/SSYKE2_7.0.0/com.ibm.java.aix.71.doc/diag/appendixes/cmdline/Xrs.html)

If you try to kill the node app after using java it won't die.  You'll have to go in and manually find the pid and kill the process.  Because java was handling the signals.  This strips that away from java and gives the control to the node app.

Now you can do things like:

```
process.on('SIGINIT', function() {
    jdbc.close(function(err) {
    if(err) {
        console.log(err);
    } else {
        console.log("Connection closed successfully!");
    }
    });
});
```

This makes life much easier, especially during development.  Super annoying to have to constantly go and kill the process.
