### PR TITLE
add libs option to config for multiple jar support

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ var jdbc = new ( require('jdbc') );
 
 var config = {
   libpath: __dirname + 'path/to/jdbc.jar',
+  libs: [__dirname + 'path/to/other/jars.jar'],
   drivername: 'com.java.driverclass',
   url: 'url/to/database',
   // optionally  

--- a/lib/jdbc.js
+++ b/lib/jdbc.js
@@ -14,8 +14,13 @@ function JDBCConn() {
 JDBCConn.prototype.initialize = function(config, callback) {
   var self = this;
   self._config = config;
-
-  java.classpath.push(self._config.libpath);
+  
+  if (self._config.libpath) {
+    java.classpath.push(self._config.libpath);
+  }
+  if (self._config.libs) {
+   java.classpath.push.apply(java.classpath, self._config.libs); 
+  }
 
   java.newInstance(self._config.drivername, function(err, driver) {
     if (err) {


### PR DESCRIPTION
This fixes #25.  I left `libpath` in to be backward compatible.  

I had trouble using the temporary fix proposed in #25 due to module caching.  I could not override the `java.classpath` for the module imported by `jdbc` by importing `java` myself.  This pull request fixed my issue.