### PR TITLE
Retrieve columns with its correct data type when possible

### DIFF
--- a/lib/jdbc.js
+++ b/lib/jdbc.js
@@ -11,6 +11,32 @@ function JDBCConn() {
   this._conn = null;
 }
 
+function getSqlTypeName() {
+    var typeNames = [''];
+    
+    typeNames[java.getStaticFieldValue("java.sql.Types", "TINYINT")]  = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "SMALLINT")] = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "INTEGER")]  = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BIGINT")]   = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "FLOAT")]    = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "REAL")]     = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DOUBLE")]   = "Double";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "NUMERIC")]  = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DECIMAL")]  = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "CHAR")]     = "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "VARCHAR")]     =  "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "LONGVARCHAR")] = "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DATE")] =  "Date";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "TIME")] =  "Time";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "TIMESTAMP")] = "Date";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BOOLEAN")] =  "Boolean";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "NCHAR")] =  "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "NVARCHAR")] = "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "LONGNVARCHAR")] = "String";
+    
+    return typeNames;
+}
+
 JDBCConn.prototype.initialize = function(config, callback) {
   var self = this;
   self._config = config;
@@ -78,6 +104,7 @@ JDBCConn.prototype.close = function(callback) {
 
 JDBCConn.prototype.executeQuery = function(sql, callback) {
   var self = this;
+  var typeNames = getSqlTypeName();
 
   self._conn.createStatement(function(err, statement) {
     if (err) {
@@ -94,17 +121,33 @@ JDBCConn.prototype.executeQuery = function(sql, callback) {
               var results = [];
               var cc = rsmd.getColumnCountSync();
               var columns = [''];
+              var types = [''];
               for(var i = 1; i <= cc; i++) {
                 var colname = rsmd.getColumnNameSync(i);
+                var coltype = rsmd.getColumnTypeSync(i);
                 columns.push(colname);
+                types.push(coltype);
               }
               var next = resultset.nextSync();
               var processRow = function(next){
                 if(next){
                   setImmediate(function(){
                     var row = {};
+                    var type = "String"; // default to string parser 
                     for(var a= 1; a <= cc; a++) {
-                      row[columns[a]] = trim1(resultset.getStringSync(a));
+                      // If we match the data type, assign its parser
+                      if (typeNames[types[a]]) {
+                         type = typeNames[types[a]];
+                      }  
+                      if (type === 'Date') {
+                        if (resultset['get' + type + 'Sync'](a)) {
+                          row[columns[a]] = resultset['get' + type + 'Sync'](a).toString();
+                        } else { // if date is empty, it should be null
+                          row[columns[a]] = null;
+                        }
+                      } else {
+                        row[columns[a]] = resultset['get' + type + 'Sync'](a);
+                      }
                     }
                     results.push(row);
                     next = resultset.nextSync();


### PR DESCRIPTION
At the moment all properties are retrieved as string, with this change it will try to match the retrieved sql column with its correct data type to the JavaScript object.