### PR TITLE
Refactored jdbc.js to call getConnection using getConnection(String u…

### DIFF
--- a/lib/jdbc.js
+++ b/lib/jdbc.js
@@ -9,17 +9,39 @@ function trim1 (str) {
 function JDBCConn() {
   this._config = {};
   this._conn = null;
+  this._props = {};
 }
 
 JDBCConn.prototype.initialize = function(config, callback) {
   var self = this;
   self._config = config;
-  
+
   if (self._config.libpath) {
     java.classpath.push(self._config.libpath);
   }
   if (self._config.libs) {
-   java.classpath.push.apply(java.classpath, self._config.libs); 
+    java.classpath.push.apply(java.classpath, self._config.libs);
+  }
+
+  if (self._config.properties){
+    var Properties = java.import('java.util.Properties');
+    var properties = new Properties();
+    self._config.properties.forEach(function(prop){
+      properties.putSync(prop[0], prop[1]);
+    });
+    this._props = properties;
+  }
+
+  if (self._config.user){
+    if(this._props.getPropertySync('user') === undefined){
+      this._props.putSync('user', self._config.user);
+    }
+  }
+
+  if (self._config.password){
+    if(this._props.getPropertySync('password') === undefined){
+      this._props.putSync('password', self._config.password);
+    }
   }
 
   java.newInstance(self._config.drivername, function(err, driver) {
@@ -39,26 +61,14 @@ JDBCConn.prototype.initialize = function(config, callback) {
 
 JDBCConn.prototype.open = function(callback) {
   var self = this;
-
-  if(self._config.user || self._config.password) {
-    java.callStaticMethod('java.sql.DriverManager', 'getConnection', self._config.url, self._config.user, self._config.password, function (err, conn) {
-      if (err) {
-        return callback(err);
-      } else {
-        self._conn = conn;
-        return callback(null, conn);
-      }
-    });
-  } else {
-    java.callStaticMethod('java.sql.DriverManager', 'getConnection', self._config.url, function (err, conn) {
-      if (err) {
-        return callback(err);
-      } else {
-        self._conn = conn;
-        return callback(null, conn);
-      }
-    });
-  }
+  java.callStaticMethod('java.sql.DriverManager', 'getConnection', self._config.url, this._props, function (err, conn) {
+    if (err) {
+      return callback(err);
+    } else {
+      self._conn = conn;
+      return callback(null, conn);
+    }
+  });
 };
 
 JDBCConn.prototype.close = function(callback) {

--- a/test/test-hsqldb.js
+++ b/test/test-hsqldb.js
@@ -1,5 +1,6 @@
 var nodeunit = require('nodeunit');
-var jdbcConn = new ( require('../lib/jdbc.js') );
+var jdbcConn = new ( require('../lib/jdbc.js') ),
+    jdbcConnWithProps = new ( require('../lib/jdbc.js') );
 
 var configWithUserInUrl = {
   libpath: './drivers/hsqldb.jar',
@@ -15,6 +16,16 @@ var configWithUserInConfig = {
   password: ''
 };
 
+var configWithPropertiesInConfig = {
+  libpath: './drivers/hsqldb.jar',
+  drivername: 'org.hsqldb.jdbc.JDBCDriver',
+  url: 'jdbc:hsqldb:hsql://localhost/xdb',
+  properties: [
+    ['user', 'SA'],
+    ['password','']
+  ]
+};
+
 module.exports = {
   tearDown: function(callback) {
     callback();
@@ -22,13 +33,29 @@ module.exports = {
   testinit: function(test) {  
     jdbcConn.initialize(configWithUserInUrl, function(err, drivername) {
       test.expect(2);
-      test.equal(null, err)
+      test.equal(null, err);
+      test.equal(drivername, 'org.hsqldb.jdbc.JDBCDriver');
+      test.done();
+    });
+  },
+  testinitwithproperties: function(test) {
+    jdbcConnWithProps.initialize(configWithPropertiesInConfig, function(err, drivername) {
+      test.expect(2);
+      test.equal(null, err);
       test.equal(drivername, 'org.hsqldb.jdbc.JDBCDriver');
       test.done();
     });
   },
   testopen: function(test) {
     jdbcConn.open(function(err, conn) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(conn);
+      test.done();
+    });
+  },
+  testopenwithproperties: function(test) {
+    jdbcConnWithProps.open(function(err, conn) {
       test.expect(2);
       test.equal(null, err);
       test.ok(conn);
@@ -43,8 +70,24 @@ module.exports = {
       test.done();
     });
   },
+  testcreatetablewithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("CREATE TABLE blahP (id int, name varchar(10));", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result);
+      test.done();
+    });
+  },
   testeqinsert: function(test) {
     jdbcConn.executeQuery("INSERT INTO blah VALUES (1, 'Jason');", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result);
+      test.done();
+    });
+  },
+  testeqinsertwithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("INSERT INTO blahP VALUES (1, 'Jason');", function(err, result) {
       test.expect(2);
       test.equal(null, err);
       test.ok(result);
@@ -59,8 +102,24 @@ module.exports = {
       test.done();
     });
   },
+  testeuinsertwithproperties: function(test) {
+    jdbcConnWithProps.executeUpdate("INSERT INTO blahP VALUES (3, 'Temp');", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result && result == 1);
+      test.done();
+    });
+  },
   testequpdate: function(test) {
     jdbcConn.executeQuery("UPDATE blah SET id = 2 WHERE name = 'Jason';", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result);
+      test.done();
+    });
+  },
+  testequpdatewithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("UPDATE blahP SET id = 2 WHERE name = 'Jason';", function(err, result) {
       test.expect(2);
       test.equal(null, err);
       test.ok(result);
@@ -75,8 +134,24 @@ module.exports = {
       test.done();
     });
   },
+  testeuupdatewithproperties: function(test) {
+    jdbcConnWithProps.executeUpdate("UPDATE blahP SET id = 4 WHERE name = 'Temp';", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result && result == 1);
+      test.done();
+    });
+  },
   testselect: function(test) {
     jdbcConn.executeQuery("SELECT * FROM blah;", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result && result.length == 2);
+      test.done();
+    });
+  },
+  testselectwithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("SELECT * FROM blahP;", function(err, result) {
       test.expect(2);
       test.equal(null, err);
       test.ok(result && result.length == 2);
@@ -91,8 +166,24 @@ module.exports = {
       test.done();
     });
   },
+  testeqdeletewithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("DELETE FROM blahP WHERE id = 2;", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result);
+      test.done();
+    });
+  },
   testeudelete: function(test) {
     jdbcConn.executeUpdate("DELETE FROM blah WHERE id = 4;", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result && result == 1);
+      test.done();
+    });
+  },
+  testeudeletewithproperties: function(test) {
+    jdbcConnWithProps.executeUpdate("DELETE FROM blahP WHERE id = 4;", function(err, result) {
       test.expect(2);
       test.equal(null, err);
       test.ok(result && result == 1);
@@ -107,6 +198,14 @@ module.exports = {
       test.done();
     });
   },
+  testdroptablewithproperties: function(test) {
+    jdbcConnWithProps.executeQuery("DROP TABLE blahP;", function(err, result) {
+      test.expect(2);
+      test.equal(null, err);
+      test.ok(result);
+      test.done();
+    });
+  },
   testshutdown: function(test) {
     jdbcConn.executeQuery("SHUTDOWN", function(err, result) {
       test.expect(2);
@@ -114,5 +213,5 @@ module.exports = {
       test.ok(result);
       test.done();
     });
-  },
+  }
 };


### PR DESCRIPTION
…rl, Properties info)

Refactored query method to only use Properties when getting a connection, which reduced the amount of code needed in the method
Added tests using properties