### PR TITLE
Add Statement.Execute Method

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -294,11 +294,10 @@ Connection.prototype.prepareCall = function(sql, callback, rstype, rsconcurrency
 
 function allType(array, type) {
   for (i = 0; i < array.length; i++) {
-    if (!(typeof array === type)) {
+    if (typeof array !== type) {
       return false;
     }
   }
-
   return true;
 }
 

--- a/lib/drivermanager.js
+++ b/lib/drivermanager.js
@@ -1,7 +1,7 @@
 var jinst = require("./jinst.js");
 var java = jinst.getInstance();
 
-const DM = 'java.sql.DriverManager';
+var DM = 'java.sql.DriverManager';
 
 module.exports = {
   getConnection: function(url, callback, propsoruser, password) {

--- a/lib/jinst.js
+++ b/lib/jinst.js
@@ -1,4 +1,3 @@
-"use strict";
 var java = require('java');
 
 function isJvmCreated() {
@@ -30,4 +29,4 @@ module.exports = {
   getInstance: function() {
     return java;
   }
-}
+};

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -57,7 +57,7 @@ Pool.prototype.status = function() {
   _.each(self._reserved, function(el) { console.log("  UUID: " + el.uuid); });
   console.log("#################################");
   console.log("");
-}
+};
 
 Pool.prototype.initialize = function(callback) {
   var self = this;

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -9,9 +9,8 @@ Statement.prototype.executeUpdate = function(sql, callback, arg1) {
       this._s.executeUpdate(sql, function(err, count) {
         if (err) {
           return callback(err);
-        } else {
-          return callback(null, count);
         }
+        return callback(null, count);
       });
     } else {
       return callback(new Error('INVALID ARGUMENTS'));
@@ -25,6 +24,34 @@ Statement.prototype.executeQuery = function(sql, callback) {
         return callback(err);
       } else {
         return callback(null, new ResultSet(resultset));
+      }
+    });
+  } else {
+    return callback(new Error('INVALID ARGUMENTS'));
+  }
+};
+
+Statement.prototype.execute = function(sql, callback) {
+  var s = this._s;
+  if (typeof sql === 'string') {
+    s.execute(sql, function(err, isResultSet) {
+      if (err) {
+        return callback(err);
+      }
+      if (isResultSet) {
+        s.getResultSet(function(err, resultset) {
+          if (err) {
+            return callback(err);
+          }
+          return callback(null, new ResultSet(resultset));
+        });
+      } else {
+        s.getUpdateCount(function(err, count) {
+          if (err) {
+            return callback(err);
+          }
+          return callback(null, count);
+        });
       }
     });
   } else {

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -113,6 +113,42 @@ exports.hsqldb = {
       }
     });
   },
+  testselectbyexecute: function(test) {
+    hsqldbconn.conn.createStatement(function(err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.execute("SELECT * FROM blah;", function(err, resultset) {
+          test.expect(7);
+          test.equal(null, err);
+          test.ok(resultset);
+          resultset.toObjArray(function(err, results) {
+            test.equal(results.length, 1);
+            test.equal(results[0].NAME, 'Jason');
+            test.ok(results[0].DATE);
+            test.ok(results[0].TIME);
+            test.ok(results[0].TIMESTAMP);
+            test.done();
+          });
+        });
+      }
+    });
+  },
+  testupdatebyexecute: function(test) {
+    hsqldbconn.conn.createStatement(function(err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.execute("UPDATE blah SET id = 2 WHERE name = 'Jason';", function(err, result) {
+          console.log('update', err, result);
+          test.expect(2);
+          test.equal(null, err);
+          test.ok(1, result);
+          test.done();
+        });
+      }
+    });
+  },
   testdelete: function(test) {
     hsqldbconn.conn.createStatement(function(err, statement) {
       if (err) {


### PR DESCRIPTION
This pull request adds the statement.execute method, which allows both queries and updates.  This is useful if you don't know the query type in advance.  I also added tests based on the existing select and update tests.

I also fixed several small warnings/errors detected by jshint.