### PR TITLE
Add toObject method that returns column labels and types

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -47,7 +47,6 @@ function ResultSet(rs) {
 ResultSet.prototype.toObjArray = function(callback) {
   this.toObject(function(err, result) {
     if (err) return callback(err);
-    console.log(result);
     callback(null, result.rows);
   });
 };

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -45,6 +45,14 @@ function ResultSet(rs) {
 }
 
 ResultSet.prototype.toObjArray = function(callback) {
+  this.toObject(function(err, result) {
+    if (err) return callback(err);
+    console.log(result);
+    callback(null, result.rows);
+  });
+};
+
+ResultSet.prototype.toObject = function(callback) {
   var self = this;
 
   self.getMetaData(function(err, rsmd) {
@@ -96,10 +104,14 @@ ResultSet.prototype.toObjArray = function(callback) {
             nextrow = self._rs.nextSync();
             processRow(nextrow);
           } else {
-            callback(null, results);
+            colsmetadata.shift();
+            callback(null, {
+              rows: results,
+              labels: _.pluck(colsmetadata, 'label'),
+              types: _.pluck(colsmetadata, 'type')
+            });
           }
         };
-
         // Process the first row.
         processRow(nextrow);
       });

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -268,6 +268,35 @@ exports.derby = {
       }
     });
   },
+  testselectobject: function(test) {
+    derbyconn.conn.createStatement(function(err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.executeQuery("SELECT * FROM blah", function(err, resultset) {
+          test.expect(13);
+          test.equal(null, err);
+          test.ok(resultset);
+          resultset.toObject(function(err, results) {
+            test.equal(results.rows.length, 1);
+            test.equal(results.rows[0].NAME, 'Jason');
+            test.ok(results.rows[0].DATE);
+            test.ok(results.rows[0].TIME);
+            test.ok(results.rows[0].TIMESTAMP);
+
+            test.equal(results.labels.length, 5);
+            test.equal(results.labels[0], 'ID');
+            test.equal(results.labels[1], 'NAME');
+            test.ok(results.labels[2], 'DATE');
+            test.ok(results.labels[3], 'TIME');
+            test.ok(results.labels[4], 'TIMESTAMP');
+            
+            test.done();
+          });
+        });
+      }
+    });
+  },
   testdelete: function(test) {
     derbyconn.conn.createStatement(function(err, statement) {
       if (err) {

--- a/test/test-multi.js
+++ b/test/test-multi.js
@@ -297,6 +297,29 @@ exports.derby = {
       }
     });
   },
+  testselectzero: function(test) {
+    derbyconn.conn.createStatement(function(err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.executeQuery("SELECT * FROM blah WHERE id = 1000", function(err, resultset) {
+          test.expect(9);
+          test.equal(null, err);
+          test.ok(resultset);
+          resultset.toObject(function(err, results) {
+            test.equal(results.rows.length, 0);
+            test.equal(results.labels.length, 5);
+            test.equal(results.labels[0], 'ID');
+            test.equal(results.labels[1], 'NAME');
+            test.ok(results.labels[2], 'DATE');
+            test.ok(results.labels[3], 'TIME');
+            test.ok(results.labels[4], 'TIMESTAMP');
+            test.done();
+          });
+        });
+      }
+    });
+  },
   testdelete: function(test) {
     derbyconn.conn.createStatement(function(err, statement) {
       if (err) {


### PR DESCRIPTION
This pull request adds a toObject method which returns the type ids and column labels along with the rows.  This is useful when no results are returned.