### PR TITLE
Changed type name for BIGINT

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -25,7 +25,7 @@ function ResultSet(rs) {
     typeNames[java.getStaticFieldValue("java.sql.Types", "TINYINT")]  = "Int";
     typeNames[java.getStaticFieldValue("java.sql.Types", "SMALLINT")] = "Int";
     typeNames[java.getStaticFieldValue("java.sql.Types", "INTEGER")]  = "Int";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "BIGINT")]   = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BIGINT")]   = "Long";
     typeNames[java.getStaticFieldValue("java.sql.Types", "FLOAT")]    = "Float";
     typeNames[java.getStaticFieldValue("java.sql.Types", "REAL")]     = "Float";
     typeNames[java.getStaticFieldValue("java.sql.Types", "DOUBLE")]   = "Double";


### PR DESCRIPTION
Before the change this error occurred: `java.sql.SQLSyntaxErrorException: incompatible data type in conversion: from SQL type BIGINT to java.lang.Integer`.

According to this table `Long` should be used as the Java type for `BIGINT`: https://docs.oracle.com/cd/E19501-01/819-3659/gcmaz/