### PR TITLE
Return rows as an iterator

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -56,6 +56,24 @@ ResultSet.prototype.toObjArray = function(callback) {
 };
 
 ResultSet.prototype.toObject = function(callback) {
+  this.toObjectIter(function(err, rs) {
+    if (err) return callback(err);
+
+    var rowIter = rs.rows;
+    var rows = [];
+    var row = rowIter.next();
+
+    while (!row.done) {
+      rows.push(row.value);
+      row = rowIter.next();
+    }
+
+    rs.rows = rows;
+    return callback(null, rs);
+  });
+};
+
+ResultSet.prototype.toObjectIter = function(callback) {
   var self = this;
 
   self.getMetaData(function(err, rsmd) {

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -80,8 +80,7 @@ ResultSet.prototype.toObjectIter = function(callback) {
     if (err) {
       return callback(err);
     } else {
-      // Add empty object to start at 1 (because ResultSet starts at 1).
-      var colsmetadata = [{}];
+      var colsmetadata = [];
 
       rsmd.getColumnCount(function(err, colcount) {
         // Get some column metadata.
@@ -104,7 +103,7 @@ ResultSet.prototype.toObjectIter = function(callback) {
 
                 // loop through each column
                 _.each(_.range(1, colcount + 1), function(i) {
-                  var cmd = colsmetadata[i];
+                  var cmd = colsmetadata[i-1];
 
                   if (self._types[cmd.type]) {
                     type = self._types[cmd.type];

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -61,9 +61,8 @@ ResultSet.prototype.toObject = function(callback) {
 
   self.getMetaData(function(err, rsmd) {
     if (err) {
-      return callback(err);
+      return callback(err)
     } else {
-      var results = [];
       // Add empty object to start at 1 (because ResultSet starts at 1).
       var colsmetadata = [{}];
 
@@ -76,55 +75,48 @@ ResultSet.prototype.toObject = function(callback) {
           });
         });
 
-        var nextrow;
+        callback(null, {
+          labels: _.pluck(colsmetadata, 'label'),
+          types: _.pluck(colsmetadata, 'type'),
+          rows: {
+            next: function() {
+              var nextRow = self._rs.nextSync();
+              if (nextRow) {
+                var result = {};
+                var type = 'String';  // Default to getStringSync getter.
 
-        async.whilst(
-          function () {
-            nextrow = self._rs.nextSync();
-            return nextrow;
-          },
-          function (cb) {
-            var result = {};
-            var type = 'String';  // Default to getStringSync getter.
+                // loop through each column
+                _.each(_.range(1, colcount + 1), function(i) {
+                  var cmd = colsmetadata[i];
 
-            // loop through each column
-            _.each(_.range(1, colcount + 1), function(i) {
-              var cmd = colsmetadata[i];
+                  if (self._types[cmd.type]) {
+                    type = self._types[cmd.type];
+                  } else {
+                    type = 'String'; // Default to getStringSync getter.
+                  }
 
-              if (self._types[cmd.type]) {
-                type = self._types[cmd.type];
+                  if (type === 'Date' || type === 'Time' || type === 'Timestamp') {
+                    if (self._rs['get' + type + 'Sync'](i)) {
+                      result[cmd.label] = self._rs['get' + type + 'Sync'](i).toString();
+                    } else { // if date is empty, it should be null
+                      result[cmd.label] = null;
+                    }
+                  } else {
+                    result[cmd.label] = self._rs['get' + type + 'Sync'](i);
+                  }
+                });
+
+                return {value: result, done: false};
               } else {
-                type = 'String'; // Default to getStringSync getter.
+                return {done: true}
               }
-
-              if (type === 'Date' || type === 'Time' || type === 'Timestamp') {
-                if (self._rs['get' + type + 'Sync'](i)) {
-                  result[cmd.label] = self._rs['get' + type + 'Sync'](i).toString();
-                } else { // if date is empty, it should be null
-                  result[cmd.label] = null;
-                }
-              } else {
-                result[cmd.label] = self._rs['get' + type + 'Sync'](i);
-              }
-            });
-
-            results.push(result);
-            cb();
-          },
-          function (err) {
-            if (err) return callback(err);
-            colsmetadata.shift();
-            callback(null, {
-              rows: results,
-              labels: _.pluck(colsmetadata, 'label'),
-              types: _.pluck(colsmetadata, 'type')
-            });
+            }
           }
-        );
+        });
       });
     }
   });
-};
+}
 
 ResultSet.prototype.close = function(callback) {
   this._rs.close(function(err) {

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -60,7 +60,7 @@ ResultSet.prototype.toObject = function(callback) {
 
   self.getMetaData(function(err, rsmd) {
     if (err) {
-      return callback(err)
+      return callback(err);
     } else {
       // Add empty object to start at 1 (because ResultSet starts at 1).
       var colsmetadata = [{}];
@@ -107,7 +107,7 @@ ResultSet.prototype.toObject = function(callback) {
 
                 return {value: result, done: false};
               } else {
-                return {done: true}
+                return {done: true};
               }
             }
           }
@@ -115,7 +115,7 @@ ResultSet.prototype.toObject = function(callback) {
       });
     }
   });
-}
+};
 
 ResultSet.prototype.close = function(callback) {
   this._rs.close(function(err) {

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -4,7 +4,6 @@ var _ = require('lodash');
 var jinst = require('./jinst');
 var ResultSetMetaData = require('./resultsetmetadata');
 var java = jinst.getInstance();
-var async = require('async');
 
 if (!jinst.isJvmCreated()) {
   jinst.addOption("-Xrs");


### PR DESCRIPTION
Large result sets cause the async bit to blow its call stack, and regardless the entire resultset gets stored in memory this way. I wanted to get your thoughts on an iterator approach, so that users can consume rows and throw them away while they do so. This is a first draft solution and certainly open to ideas.