### PR TITLE
Solution to issue #80 - Un-promisifiable / callback argument consistency issue

### DIFF
--- a/lib/callablestatement.js
+++ b/lib/callablestatement.js
@@ -1,5 +1,6 @@
 /* jshint node: true */
 "use strict";
+var _ = require('lodash');
 var PreparedStatement = require('./preparedstatement');
 
 function CallableStatement(cs) {
@@ -112,26 +113,33 @@ CallableStatement.prototype.getClob = function(arg1, callback) {
   }
 };
 
-CallableStatement.prototype.getDate = function(arg1, callback, arg2) {
-  if ((typeof arg1 === 'number' || typeof arg1 === 'string') && typeof arg2 === 'undefined') {
-    this._cs.getDate(arg1, function(err, result) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, result);
-      }
-    });
-  } else if (((typeof arg1 === 'number' || typeof arg1 === 'string') && typeof arg2 === 'object')) {
-    this._cs.getDate(arg1, arg2, function(err, result) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, result);
-      }
-    });
-  } else {
+CallableStatement.prototype.getDate = function(arg1, arg2, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  var validArgs = (
+  	(_.isNumber(args[0]) || _.isString(args[0])) &&
+		(_.isUndefined(args[1]) || _.isObject(args[1]))
+	);
+	if (! validArgs) {
     return callback(new Error("INVALID ARGUMENTS"));
-  }
+	}
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, result) {
+		if (err) {
+			return callback(err);
+		} else {
+			return callback(null, result);
+		}
+	});
+
+  // Forward modified arguments to _cs.getDate
+  this._cs.getDate.apply(this._cs, args);
 };
 
 CallableStatement.prototype.getDouble = function(arg1, callback) {
@@ -236,7 +244,7 @@ CallableStatement.prototype.getLong = function(arg1, callback) {
   }
 };
 
-CallableStatement.prototype.getObject = function(arg1, callback, arg2) {
+CallableStatement.prototype.getObject = function(arg1, arg2, callback) {
   return callback(new Error("NOT IMPLEMENTED"));
 };
 

--- a/lib/callablestatement.js
+++ b/lib/callablestatement.js
@@ -122,21 +122,21 @@ CallableStatement.prototype.getDate = function(arg1, arg2, callback) {
 
   // Check arguments for validity, and return error if invalid
   var validArgs = (
-  	(_.isNumber(args[0]) || _.isString(args[0])) &&
-		(_.isUndefined(args[1]) || _.isObject(args[1]))
-	);
-	if (! validArgs) {
+    (_.isNumber(args[0]) || _.isString(args[0])) &&
+    (_.isUndefined(args[1]) || _.isObject(args[1]))
+  );
+  if (! validArgs) {
     return callback(new Error("INVALID ARGUMENTS"));
-	}
+  }
 
   // Push a callback handler onto the arguments
   args.push(function(err, result) {
-		if (err) {
-			return callback(err);
-		} else {
-			return callback(null, result);
-		}
-	});
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, result);
+    }
+  });
 
   // Forward modified arguments to _cs.getDate
   this._cs.getDate.apply(this._cs, args);

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -85,34 +85,38 @@ Connection.prototype.createSQLXML = function(callback) {
   return callback(new Error("NOT IMPLEMENTED"));
 };
 
-Connection.prototype.createStatement = function(callback, arg1, arg2, arg3) {
-  if (typeof arg1 === 'undefined' && typeof arg2 === 'undefined' && typeof arg3 === 'undefined') {
-    this._conn.createStatement(function(err, statement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new Statement(statement));
-      }
-    });
-  } else if (typeof arg1 === 'number' && typeof arg2 === 'number' && typeof arg3 === 'undefined') {
-    this._conn.createStatement(arg1, arg2, function(err, statement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new Statement(statement));
-      }
-    });
-  } else if (typeof arg1 === 'number' && typeof arg2 === 'number' && typeof arg3 === 'number') {
-    this._conn.createStatement(arg1, arg2, arg3, function(err, statement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new Statement(statement));
-      }
-    });
-  } else {
+Connection.prototype.createStatement = function(arg1, arg2, arg3, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  var invalidArgs = false;
+  _.forEach(args, function(arg) {
+    if (! _.isNumber(arg)) {
+      invalidArgs = true;
+      // Lodash break
+      return false;
+    }
+  });
+
+  if (invalidArgs) {
     return callback(new Error("INVALID ARGUMENTS"));
   }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, statement) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, new Statement(statement));
+    }
+  });
+
+  // Forward modified arguments to _conn.createStatement
+  this._conn.createStatement.apply(this._conn, args);
 };
 
 Connection.prototype.createStruct = function(typename, attrarr, callback) {
@@ -139,24 +143,24 @@ Connection.prototype.getCatalog = function(callback) {
   });
 };
 
-Connection.prototype.getClientInfo = function(callback, name) {
-  if (name) {
-    this._conn.getClientInfo(name, function(err, value) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, value);
-      }
-    });
-  } else {
-    this._conn.getClientInfo(function(err, props) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, props);
-      }
-    });
-  }
+Connection.prototype.getClientInfo = function(name, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, result) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, result);
+    }
+  });
+
+  // Forward modified arguments to _conn.getClientInfo
+  this._conn.getClientInfo.apply(this._conn, args);
 };
 
 Connection.prototype.getHoldability = function(callback) {
@@ -265,34 +269,29 @@ Connection.prototype.nativeSQL = function(sql, callback) {
   return callback(new Error("NOT IMPLEMENTED"));
 };
 
-Connection.prototype.prepareCall = function(sql, callback, rstype, rsconcurrency, rsholdability) {
-  if (sql && !rstype && !rsconcurrency && !rsholdability) {
-    this._conn.prepareCall(sql, function(err, callablestatement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new CallableStatement(callablestatement));
-      }
-    });
-  } else if (sql && rstype && rsconcurrency && !rsholdability) {
-    this._conn.prepareCall(sql, rstype, rsconcurrency, function(err, callablestatement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new CallableStatement(callablestatement));
-      }
-    });
-  } else if (sql && rstype && rsconcurrency && rsholdability) {
-    this._conn.prepareCall(sql, rstype, rsconcurrency, rsholdability, function(err, callablestatement) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new CallableStatement(callablestatement));
-      }
-    });
-  } else {
-    return callback(new Error("INVALID ARGUMENTS!"));
+Connection.prototype.prepareCall = function(sql, rstype, rsconcurrency, rsholdability, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  if (! args[0] || (args[1] && ! args[2])) {
+    return callback(new Error("INVALID ARGUMENTS"));
   }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, callablestatement) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, new CallableStatement(callablestatement));
+    }
+  });
+
+  // Forward modified arguments to _conn.prepareCall
+  this._conn.prepareCall.apply(this._conn, args);
 };
 
 function allType(array, type) {
@@ -305,66 +304,84 @@ function allType(array, type) {
   return true;
 }
 
-Connection.prototype.prepareStatement = function(sql, callback, arg1, arg2, arg3) {
-  if (sql && typeof arg1 === 'undefined' && typeof arg2 === 'undefined' && typeof arg3 === 'undefined') {
-    this._conn.prepareStatement(sql, function(err, ps) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new PreparedStatement(ps));
-      }
-    });
-  } else if (sql && typeof arg1 === 'number' && typeof arg2 === 'undefined' && typeof arg3 === 'undefined') {
-    // arg1 is autoGeneratedKeys
-    this._conn.prepareStatement(sql, arg1, function(err, ps) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new PreparedStatement(ps));
-      }
-    });
-  } else if (sql && typeof arg1 === 'number' && typeof arg2 === 'number' && typeof arg3 === 'undefined') {
-    // arg1 is resultSetType, arg2 is resultSetConcurrency
-    this._conn.prepareStatement(sql, arg1, arg2, function(err, ps) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new PreparedStatement(ps));
-      }
-    });
-  } else if (sql && typeof arg1 === 'number' && typeof arg2 === 'number' && typeof arg3 === 'number') {
-    // arg1 is resultSetType, arg2 is resultSetConcurrency, arg3 is resultSetHoldability
-    this._conn.prepareStatement(sql, arg1, arg2, arg3, function(err, ps) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, new PreparedStatement(ps));
-      }
-    });
-  } else if (sql && typeof arg1 === 'object' && typeof arg2 === 'undefined' && typeof arg3 === 'undefined') {
-    // arg1 could be string array or a number array
-    if (Array.isArray(arg1) && allType(arg1, 'string')) {
-      this._conn.prepareStatement(sql, arg1, function(err, ps) {
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, new PreparedStatement(ps));
-        }
-      });
-    } else if (Array.isArray(arg1) && allType(arg1, 'number')) {
-      this._conn.prepareStatement(sql, arg1, function(err, ps) {
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, new PreparedStatement(ps));
-        }
-      });
-    } else {
-      return callback(new Error('INVALID ARGUMENTS'));
-    }
-  } else {
-    return callback(new Error('INVALID ARGUMENTS'));
+/**
+ * @callback prepareStatementCallback
+ * @param {Error} err - An error message, or null if no error occurred
+ * @param {PreparedStatement} prepStmt - The prepared statement
+ */
+
+/**
+ * Creates a prepared statement and returns it via callback.
+ *
+ * @param {string} sql - SQL query
+ * @param {(number | number[] | string[])} [arg1] - autoGeneratedKeys, resultSetType, or an array of numbers or strings
+ * @param {number} [arg2] - resultSetConcurrency
+ * @param {number} [arg3] - resultSetHoldability
+ * @param {prepareStatementCallback} callback - The callback that handles the prepare statement response
+ */
+Connection.prototype.prepareStatement = function(sql, arg1, arg2, arg3, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Error to return if arguments are invalid
+  var errMsg = 'INVALID ARGUMENTS';
+
+  // The first arg (sql) must be present
+  if (! args[0]) {
+    return callback(new Error(errMsg));
   }
+
+  // Check arg1, arg2, and arg3 for validity.  These arguments must
+  // be numbers if given, except for the special case when the first
+  // of these arguments is an array and no other arguments are given.
+  // In this special case, the array must be a string or number array.
+  //
+  // NOTE: _.tail returns all but the first argument, so we are only
+  // processing arg1, arg2, and arg3; and not sql (or callback, which
+  // was already removed from the args array).
+  var invalidArgs = false;
+  _.forEach(_.tail(args), function(arg, idx) {
+    // Check for the special case where arg1 can be an array of strings or numbers
+    // if arg2 and arg3 are not given
+    if (idx === 0 && _.isArray(arg) && _.isUndefined(args[1]) && _.isUndefined(args[2])) {
+      if (! (allType(arg, 'string') || allType(arg, 'number'))) {
+        invalidArgs = true;
+
+        // Lodash break
+        return false;
+      }
+
+      // Lodash continue
+      return;
+    }
+
+    // Other than the special case above, these args must be numbers
+    if (! _.isNumber(arg)) {
+      invalidArgs = true;
+
+      // Lodash break
+      return false;
+    }
+  });
+
+  if (invalidArgs) {
+    return callback(new Error(errMsg));
+  }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, ps) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, new PreparedStatement(ps));
+    }
+  });
+
+  // Forward modified arguments to _conn.prepareStatement
+  this._conn.prepareStatement.apply(this._conn, args);
 };
 
 Connection.prototype.releaseSavepoint = function(savepoint, callback) {
@@ -377,26 +394,29 @@ Connection.prototype.releaseSavepoint = function(savepoint, callback) {
   });
 };
 
-Connection.prototype.rollback = function(callback, savepoint) {
-  if (typeof savepoint === 'undefined') {
-    this._conn.rollback(function(err) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null);
-      }
-    });
-  } else if (typeof savepoint === 'object') {
-    this._conn.rollback(savepoint, function(err) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null);
-      }
-    });
-  } else {
+Connection.prototype.rollback = function(savepoint, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  if (! _.isObject(args[0])) {
     return callback(new Error("INVALID ARGUMENTS"));
   }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null);
+    }
+  });
+  
+  // Forward modified arguments to _conn.rollback
+  this._conn.rollback(this._conn, args);
 };
 
 Connection.prototype.setAutoCommit = function(autocommit, callback) {
@@ -419,26 +439,35 @@ Connection.prototype.setCatalog = function(catalog, callback) {
   });
 };
 
-Connection.prototype.setClientInfo = function(callback, props, name, value) {
-  if (typeof props === 'object' && typeof name == 'undefined' && typeof value === 'undefined') {
-    this._conn.setClientInfo(props, function(err) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null);
-      }
-    });
-  } else if (props === null && typeof name == 'string' && typeof value === 'string') {
-    this._conn.setClientInfo(name, value, function(err) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null);
-      }
-    });
+Connection.prototype.setClientInfo = function(props, name, value, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, manipulate the args array appropriately,
+  // and return error if invalid
+  if (_.isObject(args[0]) && _.isUndefined(args[1]) && _.isUndefined(args[2])) {
+    // Do nothing
+  } else if (_.isNull(args[0]) && _.isString(args[1]) && _.isString(args[2])) {
+    // Remove first argument (props) from args array
+    args.shift();
   } else {
     return callback(new Error("INVALID ARGUMENTS"));
   }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null);
+    }
+  });
+
+  // Forward modified arguments to _conn.setClientInfo
+  this._conn.setClientInfo.apply(this._conn, args);
 };
 
 Connection.prototype.setHoldability = function(holdability, callback) {
@@ -465,26 +494,29 @@ Connection.prototype.setReadOnly = function(readonly, callback) {
   });
 };
 
-Connection.prototype.setSavepoint = function(callback, name) {
-  if (typeof name === 'undefined') {
-    this._conn.setSavepoint(function(err, savepoint) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, savepoint);
-      }
-    });
-  } else if (typeof name === 'string') {
-    this._conn.setSavepoint(name, function(err, savepoint) {
-      if (err) {
-        return callback(err);
-      } else {
-        return callback(null, savepoint);
-      }
-    });
-  } else {
-    return callback('INVALID ARGUMENTS');
+Connection.prototype.setSavepoint = function(name, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  if (! (_.isUndefined(args[0]) || _.isString(args[0]))) {
+    return callback(new Error("INVALID ARGUMENTS"));
   }
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, savepoint) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, savepoint);
+    }
+  });
+
+  // Forward modified arguments to _conn.setSavepoint
+  this._conn.setSavepoint.apply(this._conn, args);
 };
 
 Connection.prototype.setSchema = function(schema, callback) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -416,7 +416,7 @@ Connection.prototype.rollback = function(savepoint, callback) {
   });
   
   // Forward modified arguments to _conn.rollback
-  this._conn.rollback(this._conn, args);
+  this._conn.rollback.apply(this._conn, args);
 };
 
 Connection.prototype.setAutoCommit = function(autocommit, callback) {

--- a/lib/drivermanager.js
+++ b/lib/drivermanager.js
@@ -8,44 +8,44 @@ var DM = 'java.sql.DriverManager';
 
 module.exports = {
   getConnection: function(url, propsoruser, password, callback) {
-		// Get arguments as an array
-		var args = Array.prototype.slice.call(arguments);
+    // Get arguments as an array
+    var args = Array.prototype.slice.call(arguments);
 
-		// Pull the callback off the end of the arguments
-		callback = args.pop();
+    // Pull the callback off the end of the arguments
+    callback = args.pop();
 
-		// Check arguments for validity, and return error if invalid
-		var validArgs = args[0] && (
-			// args[1] (propsoruser) and args[2] (password) can both be falsey
-			! (args[1] || args[2]) ||
+    // Check arguments for validity, and return error if invalid
+    var validArgs = args[0] && (
+      // args[1] (propsoruser) and args[2] (password) can both be falsey
+      ! (args[1] || args[2]) ||
 
-			// args[1] (propsoruser) and args[2] (password) can both be strings
-			(_.isString(args[1]) && _.isString(args[2])) ||
+      // args[1] (propsoruser) and args[2] (password) can both be strings
+      (_.isString(args[1]) && _.isString(args[2])) ||
 
-			// args[1] (propsoruser) can be an object if args[2] (password) is falsey
-			(_.isObject(args[1]) && ! args[2])
-		);
+      // args[1] (propsoruser) can be an object if args[2] (password) is falsey
+      (_.isObject(args[1]) && ! args[2])
+    );
 
-		if(! validArgs) {
+    if(! validArgs) {
       return callback(new Error("INVALID ARGUMENTS"));
-		}
+    }
 
-		// Push a callback handler onto the arguments
-		args.push(function(err, conn) {
-			if (err) {
-				return callback(err);
-			} else {
-				return callback(null, conn);
-			}
-		});
+    // Push a callback handler onto the arguments
+    args.push(function(err, conn) {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, conn);
+      }
+    });
 
-		// Add DM and 'getConnection' string onto beginning of args
-		// (unshift in reverse order of desired order)
-		args.unshift('getConnection');
-		args.unshift(DM);
+    // Add DM and 'getConnection' string onto beginning of args
+    // (unshift in reverse order of desired order)
+    args.unshift('getConnection');
+    args.unshift(DM);
 
-  	// Forward modified arguments to java.callStaticMethod
-  	java.callStaticMethod.apply(java, args);
+    // Forward modified arguments to java.callStaticMethod
+    java.callStaticMethod.apply(java, args);
   },
   getLoginTimeout: function(callback) {
     java.callStaticMethod(DM, 'getLoginTimeout', function(err, seconds) {

--- a/lib/drivermanager.js
+++ b/lib/drivermanager.js
@@ -1,39 +1,51 @@
 /* jshint node: true */
 "use strict";
+var _ = require('lodash');
 var jinst = require("./jinst.js");
 var java = jinst.getInstance();
 
 var DM = 'java.sql.DriverManager';
 
 module.exports = {
-  getConnection: function(url, callback, propsoruser, password) {
-    if (url && typeof propsoruser === 'string' && typeof password === 'string') {
-      java.callStaticMethod(DM, 'getConnection', url, propsoruser, password, function(err, conn) {
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, conn);
-        }
-      });
-    } else if (url && typeof propsoruser === 'object' && !password) {
-      java.callStaticMethod(DM, 'getConnection', url, propsoruser, function(err, conn) {
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, conn);
-        }
-      });
-    } else if (url && !propsoruser && !password) {
-      java.callStaticMethod(DM, 'getConnection', url, function(err, conn) {
-        if (err) {
-          return callback(err);
-        } else {
-          return callback(null, conn);
-        }
-      });
-    } else {
+  getConnection: function(url, propsoruser, password, callback) {
+		// Get arguments as an array
+		var args = Array.prototype.slice.call(arguments);
+
+		// Pull the callback off the end of the arguments
+		callback = args.pop();
+
+		// Check arguments for validity, and return error if invalid
+		var validArgs = args[0] && (
+			// args[1] (propsoruser) and args[2] (password) can both be falsey
+			! (args[1] || args[2]) ||
+
+			// args[1] (propsoruser) and args[2] (password) can both be strings
+			(_.isString(args[1]) && _.isString(args[2])) ||
+
+			// args[1] (propsoruser) can be an object if args[2] (password) is falsey
+			(_.isObject(args[1]) && ! args[2])
+		);
+
+		if(! validArgs) {
       return callback(new Error("INVALID ARGUMENTS"));
-    }
+		}
+
+		// Push a callback handler onto the arguments
+		args.push(function(err, conn) {
+			if (err) {
+				return callback(err);
+			} else {
+				return callback(null, conn);
+			}
+		});
+
+		// Add DM and 'getConnection' string onto beginning of args
+		// (unshift in reverse order of desired order)
+		args.unshift('getConnection');
+		args.unshift(DM);
+
+  	// Forward modified arguments to java.callStaticMethod
+  	java.callStaticMethod.apply(java, args);
   },
   getLoginTimeout: function(callback) {
     java.callStaticMethod(DM, 'getLoginTimeout', function(err, seconds) {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -14,13 +14,13 @@ if (!jinst.isJvmCreated()) {
 }
 
 var addConnection = function(url, props, callback) {
-  dm.getConnection(url, function(err, conn) {
+  dm.getConnection(url, props, function(err, conn) {
     if (err) {
       return callback(err);
     } else {
       return callback(null, {uuid: uuid.v4(), conn: new Connection(conn)});
     }
-  }, props);
+  });
 };
 
 function Pool(config) {

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -26,16 +26,16 @@ Statement.prototype.executeUpdate = function(sql, arg1, callback) {
 
   // Check arguments for validity, and return error if invalid
   if(! (_.isString(args[0]) && _.isUndefined(args[1]))) {
-		return callback(new Error('INVALID ARGUMENTS'));
-	}
+    return callback(new Error('INVALID ARGUMENTS'));
+  }
 
   // Push a callback handler onto the arguments
   args.push(function(err, count) {
-		if (err) {
-			return callback(err);
-		}
-		return callback(null, count);
-	});
+    if (err) {
+      return callback(err);
+    }
+    return callback(null, count);
+  });
 
   // Forward modified arguments to _s.executeUpdate
   this._s.executeUpdate.apply(this._s, args);

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -1,5 +1,6 @@
 /* jshint node: true */
 "use strict";
+var _ = require('lodash');
 var ResultSet = require('./resultset');
 
 function Statement(s) {
@@ -16,17 +17,28 @@ Statement.prototype.close = function(callback) {
   });
 };
 
-Statement.prototype.executeUpdate = function(sql, callback, arg1) {
-    if (typeof sql === 'string' && typeof arg1 === 'undefined') {
-      this._s.executeUpdate(sql, function(err, count) {
-        if (err) {
-          return callback(err);
-        }
-        return callback(null, count);
-      });
-    } else {
-      return callback(new Error('INVALID ARGUMENTS'));
-    }
+Statement.prototype.executeUpdate = function(sql, arg1, callback) {
+  // Get arguments as an array
+  var args = Array.prototype.slice.call(arguments);
+
+  // Pull the callback off the end of the arguments
+  callback = args.pop();
+
+  // Check arguments for validity, and return error if invalid
+  if(! (_.isString(args[0]) && _.isUndefined(args[1]))) {
+		return callback(new Error('INVALID ARGUMENTS'));
+	}
+
+  // Push a callback handler onto the arguments
+  args.push(function(err, count) {
+		if (err) {
+			return callback(err);
+		}
+		return callback(null, count);
+	});
+
+  // Forward modified arguments to _s.executeUpdate
+  this._s.executeUpdate.apply(this._s, args);
 };
 
 Statement.prototype.executeQuery = function(sql, callback) {

--- a/test/test-connection.js
+++ b/test/test-connection.js
@@ -115,20 +115,20 @@ module.exports = {
     });
   },
   testcreatestatement1: function(test) {
-    testconn.createStatement(function(err, statement) {
+    testconn.createStatement(0, 0, function(err, statement) {
       test.expect(2);
       test.equal(null, err);
       test.ok(statement);
       test.done();
-    }, 0, 0);
+    });
   },
   testcreatestatement2: function(test) {
-    testconn.createStatement(function(err, statement) {
+    testconn.createStatement(0, 0, 0, function(err, statement) {
       test.expect(2);
       test.equal(null, err);
       test.ok(statement);
       test.done();
-    }, 0, 0, 0);
+    });
   },
   testcreatestruct: function(test) {
     testconn.createStruct(null, null, function(err) {
@@ -311,11 +311,11 @@ module.exports = {
           if (err) {
             console.log(err);
           } else {
-            testconn.rollback(function(err) {
+            testconn.rollback(savepoint, function(err) {
               test.expect(1);
               test.equal(null, err);
               test.done();
-            }, savepoint);
+            });
           }
         });
       }
@@ -331,11 +331,11 @@ module.exports = {
   },
   testsetclientinfo: function(test) {
     // Note that HSQLDB doesn't support this feature so it errors.
-    testconn.setClientInfo(function(err){
+    testconn.setClientInfo(null, 'TEST', 'ME', function(err){
       test.expect(1);
       test.ok(err);
       test.done();
-    }, null, 'TEST', 'ME');
+    });
   },
   testsetholdability: function(test) {
     var hold = (new ResultSet(null))._holdability.indexOf('HOLD_CURSORS_OVER_COMMIT');
@@ -380,12 +380,12 @@ module.exports = {
       if (err) {
         console.log(err);
       } else {
-        testconn.setSavepoint(function(err, savepoint) {
+        testconn.setSavepoint("SAVEPOINT", function(err, savepoint) {
           test.expect(2);
           test.equal(null, err);
           test.ok(savepoint);
           test.done();
-        }, "SAVEPOINT");
+        });
       }
     });
   },


### PR DESCRIPTION
Rewrote targeted methods to pull callback off the end of the arguments list, and dynamically handle the remainder.  In general, these methods follow the general pattern (as illustrated below for Connection.setClientInfo):

```javascript
  // Get arguments as an array
  var args = Array.prototype.slice.call(arguments);

  // Pull the callback off the end of the arguments
  callback = args.pop();

  // Check arguments for validity, manipulate the args array appropriately,
  // and return error if invalid
  if (_.isObject(args[0]) && _.isUndefined(args[1]) && _.isUndefined(args[2])) {
    // Do nothing
  } else if (_.isNull(args[0]) && _.isString(args[1]) && _.isString(args[2])) {
    // Remove first argument (props) from args array
    args.shift();
  } else {
    return callback(new Error("INVALID ARGUMENTS"));
  }

  // Push a callback handler onto the arguments
  args.push(function(err) {
    if (err) {
      return callback(err);
    } else {
      return callback(null);
    }
  });

  // Forward modified arguments to _conn.setClientInfo
  this._conn.setClientInfo.apply(this._conn, args);
```

Tests were modified as well.  As previously discussed, no tests have been run.