### PR TITLE
Solution to issue #82 - Missing static constants from Statement class

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -7,6 +7,35 @@ function Statement(s) {
   this._s = s;
 }
 
+// The constant indicating that the current ResultSet object should be closed
+// when calling getMoreResults.
+Statement.CLOSE_CURRENT_RESULT = 1;
+
+// The constant indicating that the current ResultSet object should not be
+// closed when calling getMoreResults.
+Statement.KEEP_CURRENT_RESULT = 2;
+
+// The constant indicating that all ResultSet objects that have previously been
+// kept open should be closed when calling getMoreResults.
+Statement.CLOSE_ALL_RESULTS = 3;
+
+// The constant indicating that a batch statement executed successfully but that
+// no count of the number of rows it affected is available.
+Statement.SUCCESS_NO_INFO = -2;
+
+// The constant indicating that an error occured while executing a batch
+// statement.
+Statement.EXECUTE_FAILED = -3;
+
+// The constant indicating that generated keys should be made available for
+// retrieval.
+Statement.RETURN_GENERATED_KEYS = 1;
+
+// The constant indicating that generated keys should not be made available for
+// retrieval.
+Statement.NO_GENERATED_KEYS = 2;
+
+
 Statement.prototype.close = function(callback) {
   this._s.close(function(err) {
     if (err) {


### PR DESCRIPTION
Added missing constants to Statement class, including:

CLOSE_CURRENT_RESULT
KEEP_CURRENT_RESULT
CLOSE_ALL_RESULTS
SUCCESS_NO_INFO
EXECUTE_FAILED
RETURN_GENERATED_KEYS
NO_GENERATED_KEYS
