### PR TITLE
Solution to issue #82 - Missing static constants from Statement class, rev 2

### DIFF
--- a/lib/jinst.js
+++ b/lib/jinst.js
@@ -1,12 +1,19 @@
 /* jshint node: true */
 "use strict";
+var EventEmitter = require('events');
+var util = require('util');
 var java = require('java');
 
 function isJvmCreated() {
   return typeof java.onJvmCreated !== 'function';
 }
 
-module.exports = {
+function JinstEventEmitter() {
+  EventEmitter.call(this);
+}
+util.inherits(JinstEventEmitter, EventEmitter);
+
+var jinst = module.exports = {
   isJvmCreated: function() {
     return isJvmCreated();
   },
@@ -30,5 +37,6 @@ module.exports = {
   },
   getInstance: function() {
     return java;
-  }
+  },
+  events: new JinstEventEmitter(),
 };

--- a/lib/jinst.js
+++ b/lib/jinst.js
@@ -1,17 +1,12 @@
 /* jshint node: true */
 "use strict";
-var EventEmitter = require('events');
+var EventEmitter = require('events').EventEmitter;
 var util = require('util');
 var java = require('java');
 
 function isJvmCreated() {
   return typeof java.onJvmCreated !== 'function';
 }
-
-function JinstEventEmitter() {
-  EventEmitter.call(this);
-}
-util.inherits(JinstEventEmitter, EventEmitter);
 
 var jinst = module.exports = {
   isJvmCreated: function() {
@@ -38,5 +33,5 @@ var jinst = module.exports = {
   getInstance: function() {
     return java;
   },
-  events: new JinstEventEmitter(),
+  events: new EventEmitter(),
 };

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -95,6 +95,8 @@ Pool.prototype.initialize = function(callback) {
       return callback(null);
     }
   });
+
+  jinst.events.emit('initialized');
 };
 
 Pool.prototype.reserve = function(callback) {

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -7,6 +7,35 @@ function Statement(s) {
   this._s = s;
 }
 
+// The constant indicating that the current ResultSet object should be closed
+// when calling getMoreResults.
+Statement.CLOSE_CURRENT_RESULT = 1;
+
+// The constant indicating that the current ResultSet object should not be
+// closed when calling getMoreResults.
+Statement.KEEP_CURRENT_RESULT = 2;
+
+// The constant indicating that all ResultSet objects that have previously been
+// kept open should be closed when calling getMoreResults.
+Statement.CLOSE_ALL_RESULTS = 3;
+
+// The constant indicating that a batch statement executed successfully but that
+// no count of the number of rows it affected is available.
+Statement.SUCCESS_NO_INFO = -2;
+
+// The constant indicating that an error occured while executing a batch
+// statement.
+Statement.EXECUTE_FAILED = -3;
+
+// The constant indicating that generated keys should be made available for
+// retrieval.
+Statement.RETURN_GENERATED_KEYS = 1;
+
+// The constant indicating that generated keys should not be made available for
+// retrieval.
+Statement.NO_GENERATED_KEYS = 2;
+
+
 Statement.prototype.close = function(callback) {
   this._s.close(function(err) {
     if (err) {

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -9,34 +9,6 @@ function Statement(s) {
   this._s = s;
 }
 
-// The constant indicating that the current ResultSet object should be closed
-// when calling getMoreResults.
-Statement.CLOSE_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_CURRENT_RESULT');
-
-// The constant indicating that the current ResultSet object should not be
-// closed when calling getMoreResults.
-Statement.KEEP_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'KEEP_CURRENT_RESULT');
-
-// The constant indicating that all ResultSet objects that have previously been
-// kept open should be closed when calling getMoreResults.
-Statement.CLOSE_ALL_RESULTS = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_ALL_RESULTS');
-
-// The constant indicating that a batch statement executed successfully but that
-// no count of the number of rows it affected is available.
-Statement.SUCCESS_NO_INFO = java.getStaticFieldValue('java.sql.Statement', 'SUCCESS_NO_INFO');
-
-// The constant indicating that an error occured while executing a batch
-// statement.
-Statement.EXECUTE_FAILED = java.getStaticFieldValue('java.sql.Statement', 'EXECUTE_FAILED');
-
-// The constant indicating that generated keys should be made available for
-// retrieval.
-Statement.RETURN_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'RETURN_GENERATED_KEYS');
-
-// The constant indicating that generated keys should not be made available for
-// retrieval.
-Statement.NO_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'NO_GENERATED_KEYS');
-
 Statement.prototype.close = function(callback) {
   this._s.close(function(err) {
     if (err) {
@@ -152,5 +124,35 @@ Statement.prototype.setQueryTimeout = function(seconds, callback) {
     }
   });
 };
+
+jinst.events.once('initialized', function onInitialized() {
+  // The constant indicating that the current ResultSet object should be closed
+  // when calling getMoreResults.
+  Statement.CLOSE_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_CURRENT_RESULT');
+
+  // The constant indicating that the current ResultSet object should not be
+  // closed when calling getMoreResults.
+  Statement.KEEP_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'KEEP_CURRENT_RESULT');
+
+  // The constant indicating that all ResultSet objects that have previously been
+  // kept open should be closed when calling getMoreResults.
+  Statement.CLOSE_ALL_RESULTS = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_ALL_RESULTS');
+
+  // The constant indicating that a batch statement executed successfully but that
+  // no count of the number of rows it affected is available.
+  Statement.SUCCESS_NO_INFO = java.getStaticFieldValue('java.sql.Statement', 'SUCCESS_NO_INFO');
+
+  // The constant indicating that an error occured while executing a batch
+  // statement.
+  Statement.EXECUTE_FAILED = java.getStaticFieldValue('java.sql.Statement', 'EXECUTE_FAILED');
+
+  // The constant indicating that generated keys should be made available for
+  // retrieval.
+  Statement.RETURN_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'RETURN_GENERATED_KEYS');
+
+  // The constant indicating that generated keys should not be made available for
+  // retrieval.
+  Statement.NO_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'NO_GENERATED_KEYS');
+});
 
 module.exports = Statement;

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -2,6 +2,8 @@
 "use strict";
 var _ = require('lodash');
 var ResultSet = require('./resultset');
+var jinst = require('./jinst');
+var java = jinst.getInstance();
 
 function Statement(s) {
   this._s = s;
@@ -9,32 +11,31 @@ function Statement(s) {
 
 // The constant indicating that the current ResultSet object should be closed
 // when calling getMoreResults.
-Statement.CLOSE_CURRENT_RESULT = 1;
+Statement.CLOSE_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_CURRENT_RESULT');
 
 // The constant indicating that the current ResultSet object should not be
 // closed when calling getMoreResults.
-Statement.KEEP_CURRENT_RESULT = 2;
+Statement.KEEP_CURRENT_RESULT = java.getStaticFieldValue('java.sql.Statement', 'KEEP_CURRENT_RESULT');
 
 // The constant indicating that all ResultSet objects that have previously been
 // kept open should be closed when calling getMoreResults.
-Statement.CLOSE_ALL_RESULTS = 3;
+Statement.CLOSE_ALL_RESULTS = java.getStaticFieldValue('java.sql.Statement', 'CLOSE_ALL_RESULTS');
 
 // The constant indicating that a batch statement executed successfully but that
 // no count of the number of rows it affected is available.
-Statement.SUCCESS_NO_INFO = -2;
+Statement.SUCCESS_NO_INFO = java.getStaticFieldValue('java.sql.Statement', 'SUCCESS_NO_INFO');
 
 // The constant indicating that an error occured while executing a batch
 // statement.
-Statement.EXECUTE_FAILED = -3;
+Statement.EXECUTE_FAILED = java.getStaticFieldValue('java.sql.Statement', 'EXECUTE_FAILED');
 
 // The constant indicating that generated keys should be made available for
 // retrieval.
-Statement.RETURN_GENERATED_KEYS = 1;
+Statement.RETURN_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'RETURN_GENERATED_KEYS');
 
 // The constant indicating that generated keys should not be made available for
 // retrieval.
-Statement.NO_GENERATED_KEYS = 2;
-
+Statement.NO_GENERATED_KEYS = java.getStaticFieldValue('java.sql.Statement', 'NO_GENERATED_KEYS');
 
 Statement.prototype.close = function(callback) {
   this._s.close(function(err) {


### PR DESCRIPTION
Added missing constants to Statement class, including:

CLOSE_CURRENT_RESULT
KEEP_CURRENT_RESULT
CLOSE_ALL_RESULTS
SUCCESS_NO_INFO
EXECUTE_FAILED
RETURN_GENERATED_KEYS
NO_GENERATED_KEYS

Refactored the work from the previous pull request (#83), which was closed shortly after I submitted it without merging; by getting rid of hard-coded values and replacing with dynamically pulled values that came from the original Java class, ie:

java.getStaticFieldValue('java.sql.Statement', 'CLOSE_CURRENT_RESULT`);

Also fixed issue of premature initialization of JDBC caused by calling getStaticFieldValue on jinst.java too soon.  Solution implemented was to create an event emitter which emits an initialized event when a pool is initialized which triggers Statement initialization of values (via java.getStaticFieldValue).