### PR TITLE
Feature 92 - Solution to Issue #92 - Statement.getGeneratedKeys should return a wrapped ResultSet

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -126,7 +126,12 @@ Statement.prototype.setQueryTimeout = function(seconds, callback) {
 };
 
 Statement.prototype.getGeneratedKeys = function(callback) {
-  this._s.getGeneratedKeys(callback);
+  this._s.getGeneratedKeys(function(err, resultset) {
+  	if(err) {
+  		return callback(err);
+  	}
+    return callback(null, new ResultSet(resultset));
+	});
 };
 
 jinst.events.once('initialized', function onInitialized() {


### PR DESCRIPTION
Wrapping result of Statement.getGeneratedKeys with ResultSet wrapper.