### PR TITLE
Feature 94 - Solution to Issue #94

### DIFF
--- a/lib/databasemetadata.js
+++ b/lib/databasemetadata.js
@@ -19,13 +19,13 @@ function DatabaseMetaData(dbm) {
  * @returns {ResultSet} Via callback: a ResultSet object in which each row is a schema description
  */
 DatabaseMetaData.prototype.getSchemas = function(catalog, schemaPattern, callback) {
-	if(_.isFunction(catalog)) {
-		callback = catalog;
-		catalog = null;
-	} else if(_.isFunction(schemaPattern)) {
-		callback = schemaPattern;
-		schemaPattern = null;
-	}
+  if(_.isFunction(catalog)) {
+    callback = catalog;
+    catalog = null;
+  } else if(_.isFunction(schemaPattern)) {
+    callback = schemaPattern;
+    schemaPattern = null;
+  }
 
   var validParams = (
     (_.isNull(catalog) || _.isUndefined(catalog) || _.isString(catalog)) &&

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -97,35 +97,33 @@ ResultSet.prototype.toObjectIter = function(callback) {
           rows: {
             next: function() {
               var nextRow = self._rs.nextSync();
-              if (nextRow) {
-                var result = {};
-                var type = 'String';  // Default to getStringSync getter.
-
-                // loop through each column
-                _.each(_.range(1, colcount + 1), function(i) {
-                  var cmd = colsmetadata[i-1];
-
-                  if (self._types[cmd.type]) {
-                    type = self._types[cmd.type];
-                  } else {
-                    type = 'String'; // Default to getStringSync getter.
-                  }
-
-                  if (type === 'Date' || type === 'Time' || type === 'Timestamp') {
-                    if (self._rs['get' + type + 'Sync'](i)) {
-                      result[cmd.label] = self._rs['get' + type + 'Sync'](i).toString();
-                    } else { // if date is empty, it should be null
-                      result[cmd.label] = null;
-                    }
-                  } else {
-                    result[cmd.label] = self._rs['get' + type + 'Sync'](i);
-                  }
-                });
-
-                return {value: result, done: false};
-              } else {
+              if (! nextRow) {
                 return {done: true};
               }
+
+              var result = {};
+
+              // loop through each column
+              _.each(_.range(1, colcount + 1), function(i) {
+                var cmd = colsmetadata[i-1];
+                var type = self._types[cmd.type] || 'String';
+                var getter = 'get' + type + 'Sync';
+
+                if (type === 'Date' || type === 'Time' || type === 'Timestamp') {
+                  var dateVal = self._rs[getter](i);
+                  result[cmd.label] = dateVal ? dateVal.toString() : null;
+                } else {
+                  // If the column is an integer and is null, set result to null and continue
+                  if (type === 'Int' && _.isNull(self._rs.getObjectSync(i))) {
+                    result[cmd.label] = null;
+                    return;
+                  }
+
+                  result[cmd.label] = self._rs[getter](i);
+                }
+              });
+
+              return {value: result, done: false};
             }
           }
         });

--- a/lib/statement.js
+++ b/lib/statement.js
@@ -127,11 +127,11 @@ Statement.prototype.setQueryTimeout = function(seconds, callback) {
 
 Statement.prototype.getGeneratedKeys = function(callback) {
   this._s.getGeneratedKeys(function(err, resultset) {
-  	if(err) {
-  		return callback(err);
-  	}
+    if(err) {
+      return callback(err);
+    }
     return callback(null, new ResultSet(resultset));
-	});
+  });
 };
 
 jinst.events.once('initialized', function onInitialized() {


### PR DESCRIPTION
Reworked ResultSet.getObjectIter() method.  Generally refactored it, but also added logic to return null for integers rather than zero, which is detected via getObjectSync().

Also includes style fixes (tabs to spaces) for two files (lib/databasemetadata.js, lib/statement.js).