### PR TITLE
Connections are closed after they have been idle for a certain period of time

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,3 +481,15 @@ hsqldb.reserve(function(err, connObj) {
   }
 });
 ```
+
+### Automatically Closing Idle Connections
+If you pass a **maxidle** property in the config for a new connection pool,
+*pool.reserve()* will close stale connections, and will return a sufficiently fresh connection, or a new connection.
+
+**maxidle** can be number representing the maximum number of milliseconds since a connection was last used, that
+ a connection is still considered alive (without making an extra call to the database to check that the connection is valid).
+
+If **maxidle** is a falsy value or is absent from the config, this feature does not come into effect.
+
+This feature is useful, when connections are automatically closed from the server side after a certain period of time,
+and when it is not appropriate to use the connection keepalive feature.

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -80,7 +80,6 @@ function Pool(config) {
 
     return properties;
   })(config);
-  this._maxidle = config.maxidle || null;
   this._drivername = config.drivername ? config.drivername : '';
   this._minpoolsize = config.minpoolsize ? config.minpoolsize : 1;
   this._maxpoolsize = config.maxpoolsize ? config.maxpoolsize : 1;
@@ -89,6 +88,7 @@ function Pool(config) {
     query: 'select 1',
     enabled: false
   };
+  this._maxidle = (!this._keepalive.enabled && config.maxidle) || null;
   this._logging = config.logging ? config.logging : {
     level: 'error'
   };

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -25,7 +25,7 @@ var keepalive = function(conn, query) {
   });
 }
 
-var addConnection = function(url, props, ka, callback) {
+var addConnection = function(url, props, ka, maxIdle, callback) {
   dm.getConnection(url, props, function(err, conn) {
     if (err) {
       return callback(err);
@@ -36,18 +36,26 @@ var addConnection = function(url, props, ka, callback) {
         keepalive: ka.enabled ? setInterval(keepalive, ka.interval, conn, ka.query) : false
       };
 
+      if (maxIdle) {
+        connobj.lastIdle = new Date().getTime();
+      }
+
       return callback(null, connobj);
     }
   });
 };
 
-var addConnectionSync = function(url, props, ka) {
+var addConnectionSync = function(url, props, ka, maxIdle) {
   var conn = dm.getConnectionSync(url, props);
   var connobj = {
     uuid: uuid.v4(),
     conn: new Connection(conn),
     keepalive: ka.enabled ? setInterval(keepalive, ka.interval, conn, ka.query) : false
   };
+
+  if (maxIdle) {
+    connobj.lastIdle = new Date().getTime();
+  }
 
   return connobj;
 };
@@ -72,6 +80,7 @@ function Pool(config) {
 
     return properties;
   })(config);
+  this._maxidle = config.maxidle || null;
   this._drivername = config.drivername ? config.drivername : '';
   this._minpoolsize = config.minpoolsize ? config.minpoolsize : 1;
   this._maxpoolsize = config.maxpoolsize ? config.maxpoolsize : 1;
@@ -137,7 +146,7 @@ Pool.prototype.initialize = function(callback) {
   }
 
   asyncjs.times(self._minpoolsize, function(n, next){
-    addConnection(self._url, self._props, self._keepalive, function(err, conn) {
+    addConnection(self._url, self._props, self._keepalive, self._maxidle, function(err, conn) {
       next(err, conn);
     });
   }, function(err, conns) {
@@ -157,13 +166,19 @@ Pool.prototype.initialize = function(callback) {
 Pool.prototype.reserve = function(callback) {
   var self = this;
   var conn = null;
+  self._closeIdleConnections();
 
   if (self._pool.length > 0 ) {
     conn = self._pool.shift();
+
+    if (conn.lastIdle) {
+      conn.lastIdle = new Date().getTime();
+    }
+
     self._reserved.unshift(conn);
   } else if (self._reserved.length < self._maxpoolsize) {
     try {
-      conn = addConnectionSync(self._url, self._props, self._keepalive);
+      conn = addConnectionSync(self._url, self._props, self._keepalive, self._maxidle);
       self._reserved.unshift(conn);
     } catch (err) {
       winston.error(err);
@@ -178,6 +193,33 @@ Pool.prototype.reserve = function(callback) {
   }
 };
 
+Pool.prototype._closeIdleConnections = function() {
+  if (! this._maxidle) {
+    return;
+  }
+
+  var self = this;
+
+  closeIdleConnectionsInArray(self._pool, this._maxidle);
+  closeIdleConnectionsInArray(self._reserved, this._maxidle);
+};
+
+function closeIdleConnectionsInArray(array, maxIdle) {
+  var time = new Date().getTime();
+  var maxLastIdle = time - maxIdle;
+
+  for (var i = array.length - 1; i >=0; i--) {
+    var conn = array[i];
+    if (typeof conn === 'object' && conn.conn !== null) {
+      if (conn.lastIdle < maxLastIdle) {
+        console.log("closing connection because it has been idle for " + (time - conn.lastIdle) + "ms");
+        conn.conn.close(function(err) { });
+        array.splice(i, 1);
+      }
+    }
+  }
+}
+
 Pool.prototype.release = function(conn, callback) {
   var self = this;
   if (typeof conn === 'object') {
@@ -185,6 +227,11 @@ Pool.prototype.release = function(conn, callback) {
     self._reserved = _.reject(self._reserved, function(conn) {
       return conn.uuid === uuid;
     });
+
+    if (conn.lastIdle) {
+      conn.lastIdle = new Date().getTime();
+    }
+
     self._pool.unshift(conn);
     return callback(null);
   } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
   },
   "devDependencies": {
     "jshint": "~2.9",
-    "nodeunit": "~0.9"
+    "lolex": "^1.4.0",
+    "nodeunit": "~0.9",
+    "q": "^1.4.1"
   },
   "scripts": {
     "pretest": "bash bin/startdbs",

--- a/test/test-pool-maxidle.js
+++ b/test/test-pool-maxidle.js
@@ -35,25 +35,36 @@ var configWithMaxIdle = {
   maxidle: 20*60*1000 //20 minutes
 };
 
+var configWithMaxIdleAndKeepAlive = {
+  url: 'jdbc:hsqldb:hsql://localhost/xdb',
+  user : 'SA',
+  password: '',
+  minpoolsize: 1,
+  maxpoolsize: 1,
+  maxidle: 20*60*1000,
+  keepalive: {
+    interval: 45*60*1000,
+    query: 'select 1',
+    enabled: true
+  }
+};
+
+
 var testpool = null;
 var conn1Uuid = null;
 var clock = null;
 module.exports = {
   group1: {
     setUp: function(callback){
-    if (testpool === null) {
-        clock = lolex.install();
-        testpool = new Pool(config);
+      clock = lolex.install();
+      testpool = new Pool(config);
 
-        return Q.ninvoke(testpool, 'reserve')
-            .then(function (conn) {
-              conn1Uuid = conn.uuid;
-              return Q.ninvoke(testpool, 'release', conn);
-            })
-            .then(callback)
-        callback();
-      }
-      callback();
+      return Q.ninvoke(testpool, 'reserve')
+          .then(function (conn) {
+            conn1Uuid = conn.uuid;
+            return Q.ninvoke(testpool, 'release', conn);
+          })
+          .then(callback);
     },
     tearDown: function(callback) {
       clock.uninstall();
@@ -67,6 +78,7 @@ module.exports = {
             console.log(err);
           } else {
             test.expect(4);
+            //expect the same connection to be returned
             test.equal(conn1Uuid, conn.uuid);
             test.equal(null, err);
             test.equal(testpool._pool.length, 0);
@@ -79,21 +91,17 @@ module.exports = {
   group2: {
     setUp: function(callback) {
       clock = lolex.install();
+      testpool = new Pool(configWithMaxIdle);
 
-      if (testpool === null) {
-        testpool = new Pool(configWithMaxIdle);
-
-        return Q.ninvoke(testpool, 'reserve')
-            .then(function(conn) {
-              conn1Uuid = conn.uuid;
-              return Q.ninvoke(testpool, 'release', conn);
-            })
-            .then(callback)
-            .catch(function(e){
-              console.log(e);
-            });
-      }
-      callback();
+      return Q.ninvoke(testpool, 'reserve')
+          .then(function(conn) {
+            conn1Uuid = conn.uuid;
+            return Q.ninvoke(testpool, 'release', conn);
+          })
+          .then(callback)
+          .catch(function(e){
+            console.log(e);
+          });
     },
     tearDown: function(callback) {
       clock.uninstall();
@@ -106,7 +114,43 @@ module.exports = {
           console.log(err);
         } else {
           test.expect(4);
+          //expect a new connection
           test.notEqual(conn1Uuid, conn.uuid);
+          test.equal(null, err);
+          test.equal(testpool._pool.length, 0);
+          test.equal(testpool._reserved.length, 1);
+          test.done();
+        }
+      });
+    }
+  },
+  group3: {
+    setUp: function(callback) {
+      clock = lolex.install();
+
+      testpool = new Pool(configWithMaxIdleAndKeepAlive);
+
+      return Q.ninvoke(testpool, 'reserve')
+        .then(function(conn) {
+          conn1Uuid = conn.uuid;
+          return Q.ninvoke(testpool, 'release', conn);
+        })
+        .then(callback)
+        .catch(callback);
+    },
+    tearDown: function(callback) {
+      clock.uninstall();
+      callback();
+    },
+    testreserve_after_max_idle_time_with_keepalive: function(test) {
+      clock.tick("40:00");
+      testpool.reserve(function(err, conn) {
+        if (err) {
+          console.log(err);
+        } else {
+          test.expect(4);
+          //we expect the same connection to be retrieved
+          test.equals(conn1Uuid, conn.uuid);
           test.equal(null, err);
           test.equal(testpool._pool.length, 0);
           test.equal(testpool._reserved.length, 1);

--- a/test/test-pool-maxidle.js
+++ b/test/test-pool-maxidle.js
@@ -1,0 +1,118 @@
+var _ = require('lodash');
+var asyncjs = require('async');
+var nodeunit = require('nodeunit');
+var lolex = require("lolex");
+var jinst = require('../lib/jinst');
+var Pool = require('../lib/pool');
+var java = jinst.getInstance();
+var Q = require('q');
+var lolex = require("lolex");
+
+
+
+if (!jinst.isJvmCreated()) {
+  jinst.addOption("-Xrs");
+  jinst.setupClasspath(['./drivers/hsqldb.jar',
+                        './drivers/derby.jar',
+                        './drivers/derbyclient.jar',
+                        './drivers/derbytools.jar']);
+}
+
+var config = {
+  url: 'jdbc:hsqldb:hsql://localhost/xdb',
+  user : 'SA',
+  password: '',
+  minpoolsize: 1,
+  maxpoolsize: 1
+};
+
+var configWithMaxIdle = {
+  url: 'jdbc:hsqldb:hsql://localhost/xdb',
+  user : 'SA',
+  password: '',
+  minpoolsize: 1,
+  maxpoolsize: 1,
+  maxidle: 20*60*1000 //20 minutes
+};
+
+var testpool = null;
+var conn1Uuid = null;
+var clock = null;
+module.exports = {
+  group1: {
+    setUp: function(callback){
+    if (testpool === null) {
+        clock = lolex.install();
+        testpool = new Pool(config);
+
+        return Q.ninvoke(testpool, 'reserve')
+            .then(function (conn) {
+              conn1Uuid = conn.uuid;
+              return Q.ninvoke(testpool, 'release', conn);
+            })
+            .then(callback)
+        callback();
+      }
+      callback();
+    },
+    tearDown: function(callback) {
+      clock.uninstall();
+      testpool = null;
+      callback();
+    },
+    testreserve_normal: function(test) {
+        clock.tick("20:00");
+        testpool.reserve(function(err, conn) {
+          if (err) {
+            console.log(err);
+          } else {
+            test.expect(4);
+            test.equal(conn1Uuid, conn.uuid);
+            test.equal(null, err);
+            test.equal(testpool._pool.length, 0);
+            test.equal(testpool._reserved.length, 1);
+            test.done();
+          }
+        });
+    }
+  },
+  group2: {
+    setUp: function(callback) {
+      clock = lolex.install();
+
+      if (testpool === null) {
+        testpool = new Pool(configWithMaxIdle);
+
+        return Q.ninvoke(testpool, 'reserve')
+            .then(function(conn) {
+              conn1Uuid = conn.uuid;
+              return Q.ninvoke(testpool, 'release', conn);
+            })
+            .then(callback)
+            .catch(function(e){
+              console.log(e);
+            });
+      }
+      callback();
+    },
+    tearDown: function(callback) {
+      clock.uninstall();
+      callback();
+    },
+    testreserve_after_max_idle_time: function(test) {
+      clock.tick("40:00");
+      testpool.reserve(function(err, conn) {
+        if (err) {
+          console.log(err);
+        } else {
+          test.expect(4);
+          test.notEqual(conn1Uuid, conn.uuid);
+          test.equal(null, err);
+          test.equal(testpool._pool.length, 0);
+          test.equal(testpool._reserved.length, 1);
+          test.done();
+        }
+      });
+    }
+  }
+};


### PR DESCRIPTION

### Automatically Closing Idle Connections
If you pass a **maxidle** property in the config for a new connection pool,
*pool.reserve()* will close stale connections, and will return a sufficiently fresh connection, or a new connection.

**maxidle** can be number representing the maximum number of milliseconds since a connection was last used, that
 a connection is still considered alive (without making an extra call to the database to check that the connection is valid).

If **maxidle** is a falsy value or is absent from the config, this feature does not come into effect.

This feature is useful, when connections are automatically closed from the server side after a certain period of time,
and when it is not appropriate to use the connection keepalive feature.
