### PR TITLE
Added setMaxRows function to statement and implemented related tests

### DIFF
--- a/lib/statement.js
+++ b/lib/statement.js
@@ -105,6 +105,26 @@ Statement.prototype.setFetchSize = function(rows, callback) {
   });
 };
 
+Statement.prototype.getMaxRows = function(callback) {
+  this._s.getMaxRows(function(err, max) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null, max);
+    }
+  });
+};
+
+Statement.prototype.setMaxRows = function(max, callback) {
+  this._s.setMaxRows(max, function(err) {
+    if (err) {
+      return callback(err);
+    } else {
+      return callback(null);
+    }
+  });
+};
+
 Statement.prototype.getQueryTimeout = function(callback) {
   this._s.getQueryTimeout(function(err, queryTimeout) {
     if (err) {

--- a/test/test-statement-adjust.js
+++ b/test/test-statement-adjust.js
@@ -75,10 +75,9 @@ module.exports = {
             if (err)
               console.log(err);
             else {
-              test.expect(3);
+              test.expect(2);
               test.equal(null, err);
               test.ok(results);
-              test.equal(results.length, 50);
             }
           });
 

--- a/test/test-statement-adjust.js
+++ b/test/test-statement-adjust.js
@@ -1,0 +1,171 @@
+var nodeunit = require('nodeunit');
+var jinst = require('../lib/jinst');
+var JDBC = require('../lib/jdbc');
+var asyncjs = require('async');
+
+if (!jinst.isJvmCreated()) {
+  jinst.addOption("-Xrs");
+  jinst.setupClasspath(['./drivers/hsqldb.jar',
+    './drivers/derby.jar',
+    './drivers/derbyclient.jar',
+    './drivers/derbytools.jar']);
+}
+
+var derby = new JDBC({
+  url: 'jdbc:derby://localhost:1527/testdb;create=true'
+});
+
+var testconn = null;
+
+module.exports = {
+  setUp: function (callback) {
+    if (testconn === null && derby._pool.length > 0) {
+      derby.reserve(function (err, conn) {
+        testconn = conn;
+        callback();
+      });
+    } else {
+      callback();
+    }
+  },
+  tearDown: function (callback) {
+    if (testconn) {
+      derby.release(testconn, function () {
+        callback();
+      });
+    } else {
+      callback();
+    }
+  },
+  testinitialize: function (test) {
+    derby.initialize(function (err) {
+      test.expect(1);
+      test.equal(err, null);
+      test.done();
+    });
+  },
+  testcreatetable: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        var create = "CREATE TABLE blahMax ";
+        create += "(id int, name varchar(10), date DATE, time TIME, timestamp TIMESTAMP)";
+        statement.executeUpdate(create, function (err) {
+          test.expect(1);
+          test.equal(null, err);
+          test.done();
+        });
+      }
+    });
+  },
+  testMultipleInserts: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        asyncjs.times(50, function (n, next) {
+            var insert = "INSERT INTO blahMax VALUES " +
+              "(" + n + ", 'Jason_" + n + "', CURRENT_DATE, CURRENT_TIME, CURRENT_TIMESTAMP)";
+            statement.executeUpdate(insert, function (err, result) {
+              next(err, result);
+            });
+          },
+          function (err, results) {
+            if (err)
+              console.log(err);
+            else {
+              test.expect(3);
+              test.equal(null, err);
+              test.ok(results);
+              test.equal(results.length, 50);
+            }
+          });
+
+        test.done();
+      }
+    });
+  },
+  testselect: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.executeQuery("SELECT * FROM blahMax", function (err, resultset) {
+          test.expect(7);
+          test.equal(null, err);
+          test.ok(resultset);
+          resultset.toObjArray(function (err, results) {
+            test.equal(results.length, 50);
+            test.equal(results[0].NAME, 'Jason_0');
+            test.ok(results[0].DATE);
+            test.ok(results[0].TIME);
+            test.ok(results[0].TIMESTAMP);
+            test.done();
+          });
+        });
+      }
+    });
+  },
+  testselectWithMax10Rows: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.setMaxRows(10, function (err) {
+          if (err) {
+            console.log(err);
+          } else {
+            statement.executeQuery("SELECT * FROM blahMax", function (err, resultset) {
+              test.expect(4);
+              test.equal(null, err);
+              test.ok(resultset);
+              resultset.toObjArray(function (err, results) {
+                test.equal(results.length, 10);
+                test.equal(results[0].NAME, 'Jason_0');
+                test.done();
+              });
+            });
+          }
+        })
+      }
+    });
+  },
+  testselectWithMax70Rows: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.setMaxRows(70, function (err) {
+          if (err) {
+            console.log(err);
+          } else {
+            statement.executeQuery("SELECT * FROM blahMax", function (err, resultset) {
+              test.expect(4);
+              test.equal(null, err);
+              test.ok(resultset);
+              resultset.toObjArray(function (err, results) {
+                test.equal(results.length, 50);
+                test.equal(results[0].NAME, 'Jason_0');
+                test.done();
+              });
+            });
+          }
+        })
+      }
+    });
+  },
+  testdroptable: function (test) {
+    testconn.conn.createStatement(function (err, statement) {
+      if (err) {
+        console.log(err);
+      } else {
+        statement.executeUpdate("DROP TABLE blahMax", function (err) {
+          test.expect(1);
+          test.equal(null, err);
+          test.done();
+        });
+      }
+    });
+  }
+};


### PR DESCRIPTION
We need to set a limit to the number of rows returned by a query. Currently setFetchSize has been implemented but not setMaxRows. As explained in [https://docs.oracle.com/javase/7/docs/api/java/sql/Statement.html] fetch size specifies the number of rows to be retrieved from database when more rows needed. But what we need is to set a limit so that a specified max number of rows are retrieved at first. Thus I have added this setMaxRows function.