### PR TITLE
Returning new JDBC Connection error to application

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -183,6 +183,7 @@ Pool.prototype.reserve = function(callback) {
     } catch (err) {
       winston.error(err);
       conn = null;
+      return callback(err);
     }
   }
 


### PR DESCRIPTION
Hi there,

At present the Pool.prototype.reserve function will return a new Error("No more pool connections available") even when the actual error from the JDBC driver is available.

This should be passed back to the calling application's callback function instead of this more generic error.

Cheers,
Matthew