### PR TITLE
Add wrapper for CallableStatement.registerOutParameter.

### DIFF
--- a/lib/callablestatement.js
+++ b/lib/callablestatement.js
@@ -248,4 +248,20 @@ CallableStatement.prototype.getObject = function(arg1, arg2, callback) {
   return callback(new Error("NOT IMPLEMENTED"));
 };
 
+CallableStatement.prototype.registerOutParameter = function() { 
+  var args = Array.prototype.slice.call(arguments);
+  var callback = args.pop();
+  if ((typeof args[0] == 'number' && typeof args[1] == 'number') || 
+     (typeof args[0] == 'number' && typeof args[1] == 'number' && typeof args[2] == 'number') ||
+     (typeof args[0] == 'number' && typeof args[1] == 'number' && typeof args[2] == 'string') || 
+     (typeof args[0] == 'string' && typeof args[1] == 'number') || 
+     (typeof args[0] == 'string' && typeof args[1] == 'number' && typeof args[2] == 'number') || 
+     (typeof args[0] == 'string' && typeof args[1] == 'number' && typeof args[2] == 'string')) {
+    args.push(callback);
+    this._cs.registerOutParameter.apply(this._cs, args);
+  } else {
+    return callback(new Error("INVALID ARGUMENTS"));
+  }
+}
+
 module.exports = CallableStatement;


### PR DESCRIPTION
This allows for calling stored procedures with output parameters.