### PR TITLE
Fix unhandled exception in getColumnCount.

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -12,7 +12,7 @@ if (!jinst.isJvmCreated()) {
 
 function ResultSet(rs) {
   this._rs = rs;
-  this._holdability = (function() {
+  this._holdability = (function () {
     var h = [];
 
     h[java.getStaticFieldValue('java.sql.ResultSet', 'CLOSE_CURSORS_AT_COMMIT')] = 'CLOSE_CURSORS_AT_COMMIT';
@@ -20,27 +20,27 @@ function ResultSet(rs) {
 
     return h;
   })();
-  this._types = (function() {
+  this._types = (function () {
     var typeNames = [];
 
-    typeNames[java.getStaticFieldValue("java.sql.Types", "BIT")]  = "Boolean";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "TINYINT")]  = "Short";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BIT")] = "Boolean";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "TINYINT")] = "Short";
     typeNames[java.getStaticFieldValue("java.sql.Types", "SMALLINT")] = "Short";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "INTEGER")]  = "Int";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "BIGINT")]   = "String";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "FLOAT")]    = "Float";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "REAL")]     = "Float";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "DOUBLE")]   = "Double";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "NUMERIC")]  = "BigDecimal";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "DECIMAL")]  = "BigDecimal";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "CHAR")]     = "String";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "VARCHAR")]     =  "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "INTEGER")] = "Int";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BIGINT")] = "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "FLOAT")] = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "REAL")] = "Float";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DOUBLE")] = "Double";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "NUMERIC")] = "BigDecimal";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DECIMAL")] = "BigDecimal";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "CHAR")] = "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "VARCHAR")] = "String";
     typeNames[java.getStaticFieldValue("java.sql.Types", "LONGVARCHAR")] = "String";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "DATE")] =  "Date";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "TIME")] =  "Time";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "DATE")] = "Date";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "TIME")] = "Time";
     typeNames[java.getStaticFieldValue("java.sql.Types", "TIMESTAMP")] = "Timestamp";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "BOOLEAN")] =  "Boolean";
-    typeNames[java.getStaticFieldValue("java.sql.Types", "NCHAR")] =  "String";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "BOOLEAN")] = "Boolean";
+    typeNames[java.getStaticFieldValue("java.sql.Types", "NCHAR")] = "String";
     typeNames[java.getStaticFieldValue("java.sql.Types", "NVARCHAR")] = "String";
     typeNames[java.getStaticFieldValue("java.sql.Types", "LONGNVARCHAR")] = "String";
     typeNames[java.getStaticFieldValue("java.sql.Types", "BINARY")] = "Bytes";
@@ -52,15 +52,15 @@ function ResultSet(rs) {
   })();
 }
 
-ResultSet.prototype.toObjArray = function(callback) {
-  this.toObject(function(err, result) {
+ResultSet.prototype.toObjArray = function (callback) {
+  this.toObject(function (err, result) {
     if (err) return callback(err);
     callback(null, result.rows);
   });
 };
 
-ResultSet.prototype.toObject = function(callback) {
-  this.toObjectIter(function(err, rs) {
+ResultSet.prototype.toObject = function (callback) {
+  this.toObjectIter(function (err, rs) {
     if (err) return callback(err);
 
     var rowIter = rs.rows;
@@ -77,18 +77,22 @@ ResultSet.prototype.toObject = function(callback) {
   });
 };
 
-ResultSet.prototype.toObjectIter = function(callback) {
+ResultSet.prototype.toObjectIter = function (callback) {
   var self = this;
 
-  self.getMetaData(function(err, rsmd) {
+  self.getMetaData(function (err, rsmd) {
     if (err) {
       return callback(err);
     } else {
       var colsmetadata = [];
 
-      rsmd.getColumnCount(function(err, colcount) {
+      rsmd.getColumnCount(function (err, colcount) {
+
+        if (err)
+          return callback(err);
+
         // Get some column metadata.
-        _.each(_.range(1, colcount + 1), function(i) {
+        _.each(_.range(1, colcount + 1), function (i) {
           colsmetadata.push({
             label: rsmd._rsmd.getColumnLabelSync(i),
             type: rsmd._rsmd.getColumnTypeSync(i)
@@ -99,17 +103,19 @@ ResultSet.prototype.toObjectIter = function(callback) {
           labels: _.map(colsmetadata, 'label'),
           types: _.map(colsmetadata, 'type'),
           rows: {
-            next: function() {
+            next: function () {
               var nextRow = self._rs.nextSync();
-              if (! nextRow) {
-                return {done: true};
+              if (!nextRow) {
+                return {
+                  done: true
+                };
               }
 
               var result = {};
 
               // loop through each column
-              _.each(_.range(1, colcount + 1), function(i) {
-                var cmd = colsmetadata[i-1];
+              _.each(_.range(1, colcount + 1), function (i) {
+                var cmd = colsmetadata[i - 1];
                 var type = self._types[cmd.type] || 'String';
                 var getter = 'get' + type + 'Sync';
 
@@ -127,7 +133,10 @@ ResultSet.prototype.toObjectIter = function(callback) {
                 }
               });
 
-              return {value: result, done: false};
+              return {
+                value: result,
+                done: false
+              };
             }
           }
         });
@@ -136,8 +145,8 @@ ResultSet.prototype.toObjectIter = function(callback) {
   });
 };
 
-ResultSet.prototype.close = function(callback) {
-  this._rs.close(function(err) {
+ResultSet.prototype.close = function (callback) {
+  this._rs.close(function (err) {
     if (err) {
       return callback(err);
     } else {
@@ -146,8 +155,8 @@ ResultSet.prototype.close = function(callback) {
   });
 };
 
-ResultSet.prototype.getMetaData = function(callback) {
-  this._rs.getMetaData(function(err, rsmd) {
+ResultSet.prototype.getMetaData = function (callback) {
+  this._rs.getMetaData(function (err, rsmd) {
     if (err) {
       return callback(err);
     } else {

--- a/lib/resultsetmetadata.js
+++ b/lib/resultsetmetadata.js
@@ -1,15 +1,21 @@
 /* jshint node: true */
 "use strict";
+
 function ResultSetMetaData(rsmd) {
   this._rsmd = rsmd;
 }
 
 ResultSetMetaData.prototype.getColumnCount = function (callback) {
-  this._rsmd.getColumnCount(function(err, count) {
-    if (err) {
+  this._rsmd.getColumnCount(function (err, count) {
+    try {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, count);
+      }
+    } catch (err) {
+      log.debug('getColumnCount ERR!!!', err);
       return callback(err);
-    } else {
-      return callback(null, count);
     }
   });
 };


### PR DESCRIPTION
Hi,
I've added exception handling in getColumnCount, and error checking in resultset.js -> toObjectIter.
Currently, if an the exception is raised during toObjectArray method - we cannot overcome it, and handle the returned error properly.