### PR TITLE
Fix ResultSet MSSQL datatype error for autoincrement

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -123,9 +123,18 @@ ResultSet.prototype.toObjectIter = function (callback) {
                   var dateVal = self._rs[getter](i);
                   result[cmd.label] = dateVal ? dateVal.toString() : null;
                 } else {
+                  var rawObject = self._rs.getObjectSync(i);
+
                   // If the column is an integer and is null, set result to null and continue
-                  if (type === 'Int' && _.isNull(self._rs.getObjectSync(i))) {
+                  if (type === 'Int' && _.isNull(rawObject)) {
                     result[cmd.label] = null;
+                    return;
+                  }
+
+                  // IS_AUTOINCREMENT in MSSQL sometimes returns 'YES' and 'NO' (which is correct per JDBC spec)
+                  // Since it's a Short here it must be converted
+                  if (cmd.label === 'IS_AUTOINCREMENT' && _.isString(rawObject)) {
+                    result[cmd.label] = (rawObject === 'YES') ? 1 : 0;
                     return;
                   }
 

--- a/lib/resultsetmetadata.js
+++ b/lib/resultsetmetadata.js
@@ -14,7 +14,6 @@ ResultSetMetaData.prototype.getColumnCount = function (callback) {
         return callback(null, count);
       }
     } catch (err) {
-      log.debug('getColumnCount ERR!!!', err);
       return callback(err);
     }
   });


### PR DESCRIPTION
[JDBC documentation](https://docs.oracle.com/javase/7/docs/api/java/sql/DatabaseMetaData.html#getColumns(java.lang.String,%20java.lang.String,%20java.lang.String,%20java.lang.String)) for `getColumns` describes the `IS_AUTOINCREMENT` field as being a `string` with the value `YES|NO|empty`.  In this library it's attempting to parse the string as a `short` from that string and failing.

There's probably a better long-term solution but this change allows MSSQL to work properly in the short-term.  I also removed a logging statement which prevented the error from bubbling up.

[Potentially relevant SO post?](https://stackoverflow.com/questions/20028108/why-is-the-is-autoincrement-metadata-column-returning-inconsistent-values-based)