### PR TITLE
Fix Java RuntimeException for failed queries.

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -106,7 +106,7 @@ ResultSet.prototype.toObjectIter = function (callback) {
             next: function () {
               var nextRow;
               try {
-                nextRow = self._rs.nextSync(); // this row can lead to JavaRunTimeException - sould be cathced.
+                nextRow = self._rs.nextSync(); // this row can lead to Java RuntimeException - sould be cathced.
               } 
               catch (error) {
                 callback(error);

--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -104,7 +104,13 @@ ResultSet.prototype.toObjectIter = function (callback) {
           types: _.map(colsmetadata, 'type'),
           rows: {
             next: function () {
-              var nextRow = self._rs.nextSync();
+              var nextRow;
+              try {
+                nextRow = self._rs.nextSync(); // this row can lead to JavaRunTimeException - sould be cathced.
+              } 
+              catch (error) {
+                callback(error);
+              }
               if (!nextRow) {
                 return {
                   done: true


### PR DESCRIPTION
In some rare cases, when the query fails entirely, a run-time exception is thrown (and not handled):
'Reject row count exceeded.',
     '\r',
     '\tat sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)\r',
     '\tat sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)\r',
     '\tat sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)\r',
     '\tat java.lang.reflect.Method.invoke(Method.java:498)\r',
     '',
     '    at Object.next (node_modules\\jdbc\\lib\\resultset.js:103:38)',
     '    at node_modules\\jdbc\\lib\\resultset.js:68:23',
     '    at node_modules\\jdbc\\lib\\resultset.js:98:9',
     '    at node_modules\\jdbc\\lib\\resultsetmetadata.js:12:14' ] }