### PR TITLE
fix(Pool): fix parameters initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.log
 node_modules
 mydb.*
+.idea/

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -70,11 +70,15 @@ function Pool(config) {
       properties.putSync(name, config.properties[name]);
     }
 
-    if (config.user && properties.getPropertySync('user') === undefined) {
+    // NOTE: https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#getProperty(java.lang.String)
+    // if property does not exist it returns 'null' in the new java version, so we can use _.isNil to support
+    // older versions as well
+
+    if (config.user && _.isNil(properties.getPropertySync('user'))) {
       properties.putSync('user', config.user);
     }
 
-    if (config.password && properties.getPropertySync('password') === undefined) {
+    if (config.password && _.isNil(properties.getPropertySync('password'))) {
       properties.putSync('password', config.password);
     }
 


### PR DESCRIPTION
The function call [properties.getPropertySync('user' | 'password')](https://docs.oracle.com/javase/7/docs/api/java/util/Properties.html#getProperty(java.lang.String)) does not return `undefined` in the new versions of java anymore, instead it now returns `null`.

To fix this bug i used the `_.isNil` function from [lodash](https://lodash.com/docs/4.17.10#isNil), so it can handle both cases.