### PR TITLE
fix for callback was already called - failing pool initialization code path 

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -127,7 +127,7 @@ Pool.prototype.status = function(callback) {
   callback(null, status);
 };
 
-Pool.prototype.addConnectionsOnInitialize = function(callback){
+Pool.prototype._addConnectionsOnInitialize = function(callback){
   var self = this;
   asyncjs.times(self._minpoolsize, function(n, next){
     addConnection(self._url, self._props, self._keepalive, self._maxidle, function(err, conn) {
@@ -161,10 +161,13 @@ Pool.prototype.initialize = function(callback) {
           if (err) {
             return callback(err);
           }
-          self.addConnectionsOnInitialize(callback);
+          self._addConnectionsOnInitialize(callback);
         });
       }
     });
+  }
+  else {
+    self._addConnectionsOnInitialize(callback);
   }
 
   jinst.events.emit('initialized');

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -127,6 +127,23 @@ Pool.prototype.status = function(callback) {
   callback(null, status);
 };
 
+Pool.prototype.addConnectionsOnInitialize = function(callback){
+  var self = this;
+  asyncjs.times(self._minpoolsize, function(n, next){
+    addConnection(self._url, self._props, self._keepalive, self._maxidle, function(err, conn) {
+      next(err, conn);
+    });
+  }, function(err, conns) {
+    if (err) {
+      return callback(err);
+    } else {
+      _.each(conns, function(conn) {
+        self._pool.push(conn);
+      });
+      return callback(null);
+    }
+  });
+};
 
 Pool.prototype.initialize = function(callback) {
   var self = this;
@@ -144,25 +161,11 @@ Pool.prototype.initialize = function(callback) {
           if (err) {
             return callback(err);
           }
+          self.addConnectionsOnInitialize(callback);
         });
       }
     });
   }
-
-  asyncjs.times(self._minpoolsize, function(n, next){
-    addConnection(self._url, self._props, self._keepalive, self._maxidle, function(err, conn) {
-      next(err, conn);
-    });
-  }, function(err, conns) {
-    if (err) {
-      return callback(err);
-    } else {
-      _.each(conns, function(conn) {
-        self._pool.push(conn);
-      });
-      return callback(null);
-    }
-  });
 
   jinst.events.emit('initialized');
 };


### PR DESCRIPTION
Description:
-
Pool initialization fails when driver class name is passed for non-existing driver jars in classpath.

Steps to reproduce issue:
-
- Initialize pool with invalid drivername
- `java.newInstance` method call will return error and the callback will be called
```
java.lang.NoClassDefFoundError: org/postgresql/Driver
Caused by: java.lang.ClassNotFoundException: org.postgresql.Driver
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
```
- `addConnection` will also fail and try to call callback again (https://github.com/CraZySacX/node-jdbc/blob/master/lib/pool.js#L153) 

```
java.sql.SQLException: No suitable driver found for jdbc:postgresql://sl-us-south-1-portal.8.dblayer.com:27422/compose
	at java.sql.DriverManager.getConnection(DriverManager.java:689)
	at java.sql.DriverManager.getConnection(DriverManager.java:208)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```
 Hence, It error out with: Callback was already called.

Ideally, we should synchronize `java.newInstance` with `addConnection` rather than running them in parallel.