### PR TITLE
add getColumnName method to ResultSetMetaData class

### DIFF
--- a/lib/resultsetmetadata.js
+++ b/lib/resultsetmetadata.js
@@ -19,4 +19,18 @@ ResultSetMetaData.prototype.getColumnCount = function (callback) {
   });
 };
 
+ResultSetMetaData.prototype.getColumnName = function (column, callback) {
+  this._rsmd.getColumnName(column, function (err, name) {
+    try {
+      if (err) {
+        return callback(err);
+      } else {
+        return callback(null, name);
+      }
+    } catch (err) {
+      return callback(err);
+    }
+  });
+};
+
 module.exports = ResultSetMetaData;


### PR DESCRIPTION
Added `getColumnName` method to `ResultSetMetaData` class

Get the designated column's name.
**Parameters:**
column - the first column is 1, the second is 2, ...
**Returns:**
column name

https://docs.oracle.com/javase/8/docs/api/java/sql/ResultSetMetaData.html#getColumnName-int-