### PR TITLE
BigDecimal fix

### DIFF
--- a/lib/resultset.js
+++ b/lib/resultset.js
@@ -123,6 +123,7 @@ ResultSet.prototype.toObjectIter = function (callback) {
               _.each(_.range(1, colcount + 1), function (i) {
                 var cmd = colsmetadata[i - 1];
                 var type = self._types[cmd.type] || 'String';
+                if(type === 'BigDecimal') type = 'Int';
                 var getter = 'get' + type + 'Sync';
 
                 if (type === 'Date' || type === 'Time' || type === 'Timestamp') {


### PR DESCRIPTION
Without the BigDecimal type identification (when encountered using UniVerse and UniData U2 jdbc drivers), values are incorrectly interpreted as strings.